### PR TITLE
Reorganize typings

### DIFF
--- a/.changeset/tame-mirrors-remember.md
+++ b/.changeset/tame-mirrors-remember.md
@@ -1,0 +1,7 @@
+---
+'@dgac/nmb2b-client': patch
+---
+
+All B2B types are now exported.
+
+Fix `AUPSummary.notes` typing.

--- a/src/Airspace/queryCompleteAIXMDatasets.ts
+++ b/src/Airspace/queryCompleteAIXMDatasets.ts
@@ -9,7 +9,7 @@ import type {
   CompleteAIXMDatasetRequest,
 } from './types';
 
-export { CompleteAIXMDatasetReply, CompleteAIXMDatasetRequest } from './types';
+export type { CompleteAIXMDatasetReply, CompleteAIXMDatasetRequest } from './types';
 
 type Values = CompleteAIXMDatasetRequest;
 type Result = CompleteAIXMDatasetReply;

--- a/src/Airspace/queryCompleteAIXMDatasets.ts
+++ b/src/Airspace/queryCompleteAIXMDatasets.ts
@@ -3,21 +3,13 @@ import { instrument } from '../utils/instrumentation';
 import { injectSendTime, responseStatusHandler } from '../utils/internals';
 import { prepareSerializer } from '../utils/transformers';
 import type { AirspaceClient } from './';
-import type { AiracIdentifier, AIXMFile } from './types';
 
 import type {
-  DateYearMonthDay,
-  DateYearMonthDayPeriod,
-  ReplyWithData,
-} from '../Common/types';
+  CompleteAIXMDatasetReply,
+  CompleteAIXMDatasetRequest,
+} from './types';
 
-export interface CompleteAIXMDatasetRequest {
-  queryCriteria: CompleteDatasetQueryCriteria;
-}
-
-export type CompleteAIXMDatasetReply = ReplyWithData<{
-  datasetSummaries: CompleteDatasetSummary[];
-}>;
+export { CompleteAIXMDatasetReply, CompleteAIXMDatasetRequest } from './types';
 
 type Values = CompleteAIXMDatasetRequest;
 type Result = CompleteAIXMDatasetReply;
@@ -52,15 +44,3 @@ export default function prepareQueryCompleteAIXMDatasets(
       }),
   );
 }
-
-interface CompleteDatasetSummary {
-  updateId: string;
-  publicationDate: DateYearMonthDay;
-  sourceAIRACs: [AiracIdentifier] | [AiracIdentifier, AiracIdentifier];
-  files: AIXMFile[];
-}
-
-type CompleteDatasetQueryCriteria =
-  | { publicationPeriod: DateYearMonthDayPeriod }
-  | { airac: AiracIdentifier }
-  | { date: DateYearMonthDay };

--- a/src/Airspace/retrieveAUP.ts
+++ b/src/Airspace/retrieveAUP.ts
@@ -1,10 +1,11 @@
-import type { ReplyWithData } from '../Common/types';
 import type { SoapOptions } from '../soap';
 import { instrument } from '../utils/instrumentation';
 import { injectSendTime, responseStatusHandler } from '../utils/internals';
 import { prepareSerializer } from '../utils/transformers';
 import type { AirspaceClient } from './';
-import type { AUP, AUPId } from './types';
+
+import type { AUPRetrievalReply, AUPRetrievalRequest } from './types';
+export type { AUPRetrievalReply, AUPRetrievalRequest };
 
 type Values = AUPRetrievalRequest;
 type Result = AUPRetrievalReply;
@@ -37,12 +38,3 @@ export default function prepareRetrieveAUP(client: AirspaceClient): Resolver {
       }),
   );
 }
-
-export interface AUPRetrievalRequest {
-  aupId: AUPId;
-  returnComputed?: boolean;
-}
-
-export type AUPRetrievalReply = ReplyWithData<{
-  aup: AUP;
-}>;

--- a/src/Airspace/retrieveAUPChain.ts
+++ b/src/Airspace/retrieveAUPChain.ts
@@ -1,15 +1,10 @@
-import type {
-  AirNavigationUnitId,
-  DateYearMonthDay,
-  ReplyWithData,
-} from '../Common/types';
 import type { SoapOptions } from '../soap';
 import { instrument } from '../utils/instrumentation';
 import { injectSendTime, responseStatusHandler } from '../utils/internals';
 import { prepareSerializer } from '../utils/transformers';
 import type { AirspaceClient } from './';
-
-import type { AUPChain } from './types';
+import type { AUPChainRetrievalReply, AUPChainRetrievalRequest } from './types';
+export type { AUPChainRetrievalReply, AUPChainRetrievalRequest };
 
 type Values = AUPChainRetrievalRequest;
 type Result = AUPChainRetrievalReply;
@@ -44,12 +39,3 @@ export default function prepareRetrieveAUPChain(
       }),
   );
 }
-
-export interface AUPChainRetrievalRequest {
-  chainDate: DateYearMonthDay;
-  amcIds?: AirNavigationUnitId[];
-}
-
-export type AUPChainRetrievalReply = ReplyWithData<{
-  chains: AUPChain[];
-}>;

--- a/src/Airspace/retrieveEAUPChain.ts
+++ b/src/Airspace/retrieveEAUPChain.ts
@@ -1,11 +1,14 @@
-import type { DateYearMonthDay, ReplyWithData } from '../Common/types';
 import type { SoapOptions } from '../soap';
 import { instrument } from '../utils/instrumentation';
 import { injectSendTime, responseStatusHandler } from '../utils/internals';
 import { prepareSerializer } from '../utils/transformers';
 import type { AirspaceClient } from './';
+import type {
+  EAUPChainRetrievalReply,
+  EAUPChainRetrievalRequest,
+} from './types';
 
-import type { EAUPChain } from './types';
+export type { EAUPChainRetrievalReply, EAUPChainRetrievalRequest };
 
 type Values = EAUPChainRetrievalRequest;
 type Result = EAUPChainRetrievalReply;
@@ -40,11 +43,3 @@ export default function prepareRetrieveEAUPChain(
       }),
   );
 }
-
-export interface EAUPChainRetrievalRequest {
-  chainDate: DateYearMonthDay;
-}
-
-export type EAUPChainRetrievalReply = ReplyWithData<{
-  chain: EAUPChain;
-}>;

--- a/src/Airspace/types.ts
+++ b/src/Airspace/types.ts
@@ -54,6 +54,7 @@ import type {
   DistanceNM,
   LastUpdate,
   Position,
+  ReplyWithData,
 } from '../Common/types';
 
 export interface AUPChain {
@@ -305,3 +306,37 @@ export interface FlightLevelRange {
   min: FlightLevel;
   max: FlightLevel;
 }
+
+export interface CompleteAIXMDatasetRequest {
+  queryCriteria: CompleteDatasetQueryCriteria;
+}
+
+export type CompleteAIXMDatasetReply = ReplyWithData<{
+  datasetSummaries: CompleteDatasetSummary[];
+}>;
+
+export interface AUPRetrievalRequest {
+  aupId: AUPId;
+  returnComputed?: boolean;
+}
+
+export type AUPRetrievalReply = ReplyWithData<{
+  aup: AUP;
+}>;
+
+export interface AUPChainRetrievalRequest {
+  chainDate: DateYearMonthDay;
+  amcIds?: AirNavigationUnitId[];
+}
+
+export type AUPChainRetrievalReply = ReplyWithData<{
+  chains: AUPChain[];
+}>;
+
+export interface EAUPChainRetrievalRequest {
+  chainDate: DateYearMonthDay;
+}
+
+export type EAUPChainRetrievalReply = ReplyWithData<{
+  chain: EAUPChain;
+}>;

--- a/src/Airspace/types.ts
+++ b/src/Airspace/types.ts
@@ -82,7 +82,7 @@ export interface AUPSummary {
   aupState: AUPState;
   nilAUP: boolean;
   remark: string;
-  note: Array<string | null>;
+  note: Array<string>;
   expandedAUP: boolean;
   lastUpdate?: LastUpdate;
   isP3?: boolean;

--- a/src/Flight/queryFlightPlans.ts
+++ b/src/Flight/queryFlightPlans.ts
@@ -4,7 +4,7 @@ import type { SoapOptions } from '../soap';
 import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 import type { FlightPlanListRequest, FlightPlanListReply } from './types';
-export { FlightPlanListRequest, FlightPlanListReply } from './types';
+export type { FlightPlanListRequest, FlightPlanListReply } from './types';
 
 type Values = FlightPlanListRequest;
 type Result = FlightPlanListReply;

--- a/src/Flight/queryFlightsByAirspace.ts
+++ b/src/Flight/queryFlightsByAirspace.ts
@@ -9,7 +9,7 @@ import type {
   FlightListByAirspaceReply,
 } from './types';
 
-export {
+export type {
   FlightListByAirspaceRequest,
   FlightListByAirspaceReply,
 } from './types';

--- a/src/Flight/queryFlightsByMeasure.ts
+++ b/src/Flight/queryFlightsByMeasure.ts
@@ -8,7 +8,11 @@ import type {
   FlightListByMeasureRequest,
   FlightListByMeasureReply,
 } from './types';
-export { FlightListByMeasureRequest, FlightListByMeasureReply } from './types';
+
+export type {
+  FlightListByMeasureRequest,
+  FlightListByMeasureReply,
+} from './types';
 
 type Values = FlightListByMeasureRequest;
 type Result = FlightListByMeasureReply;

--- a/src/Flight/queryFlightsByTrafficVolume.ts
+++ b/src/Flight/queryFlightsByTrafficVolume.ts
@@ -9,7 +9,7 @@ import type {
   FlightListByTrafficVolumeReply,
 } from './types';
 
-export {
+export type {
   FlightListByTrafficVolumeRequest,
   FlightListByTrafficVolumeReply,
 } from './types';

--- a/src/Flight/retrieveFlight.ts
+++ b/src/Flight/retrieveFlight.ts
@@ -5,7 +5,7 @@ import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 
 import type { FlightRetrievalRequest, FlightRetrievalReply } from './types';
-export { FlightRetrievalRequest, FlightRetrievalReply } from './types';
+export type { FlightRetrievalRequest, FlightRetrievalReply } from './types';
 
 type Values = FlightRetrievalRequest;
 type Result = FlightRetrievalReply;

--- a/src/Flow/queryHotspots.ts
+++ b/src/Flow/queryHotspots.ts
@@ -5,7 +5,7 @@ import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 
 import type { HotspotListRequest, HotspotListReply } from './types';
-export { HotspotListRequest, HotspotListReply } from './types';
+export type { HotspotListRequest, HotspotListReply } from './types';
 
 type Values = HotspotListRequest;
 type Result = HotspotListReply;

--- a/src/Flow/queryRegulations.ts
+++ b/src/Flow/queryRegulations.ts
@@ -5,7 +5,7 @@ import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 
 import type { RegulationListRequest, RegulationListReply } from './types';
-export { RegulationListRequest, RegulationListReply } from './types';
+export type { RegulationListRequest, RegulationListReply } from './types';
 
 type Values = RegulationListRequest;
 type Result = RegulationListReply;

--- a/src/Flow/queryTrafficCountsByAirspace.ts
+++ b/src/Flow/queryTrafficCountsByAirspace.ts
@@ -9,7 +9,7 @@ import type {
   TrafficCountsByAirspaceReply,
 } from './types';
 
-export {
+export type {
   TrafficCountsByAirspaceRequest,
   TrafficCountsByAirspaceReply,
 } from './types';

--- a/src/Flow/queryTrafficCountsByTrafficVolume.ts
+++ b/src/Flow/queryTrafficCountsByTrafficVolume.ts
@@ -9,7 +9,7 @@ import type {
   TrafficCountsByTrafficVolumeReply,
 } from './types';
 
-export {
+export type {
   TrafficCountsByTrafficVolumeRequest,
   TrafficCountsByTrafficVolumeReply,
 } from './types';

--- a/src/Flow/retrieveCapacityPlan.ts
+++ b/src/Flow/retrieveCapacityPlan.ts
@@ -9,7 +9,7 @@ import type {
   CapacityPlanRetrievalReply,
 } from './types';
 
-export {
+export type {
   CapacityPlanRetrievalRequest,
   CapacityPlanRetrievalReply,
 } from './types';

--- a/src/Flow/retrieveOTMVPlan.ts
+++ b/src/Flow/retrieveOTMVPlan.ts
@@ -5,7 +5,7 @@ import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 
 import type { OTMVPlanRetrievalRequest, OTMVPlanRetrievalReply } from './types';
-export { OTMVPlanRetrievalRequest, OTMVPlanRetrievalReply } from './types';
+export type { OTMVPlanRetrievalRequest, OTMVPlanRetrievalReply } from './types';
 
 export type Values = OTMVPlanRetrievalRequest;
 export type Result = OTMVPlanRetrievalReply;

--- a/src/Flow/retrieveRunwayConfigurationPlan.ts
+++ b/src/Flow/retrieveRunwayConfigurationPlan.ts
@@ -8,7 +8,8 @@ import type {
   RunwayConfigurationPlanRetrievalRequest,
   RunwayConfigurationPlanRetrievalReply,
 } from './types';
-export {
+
+export type {
   RunwayConfigurationPlanRetrievalRequest,
   RunwayConfigurationPlanRetrievalReply,
 } from './types';

--- a/src/Flow/retrieveSectorConfigurationPlan.ts
+++ b/src/Flow/retrieveSectorConfigurationPlan.ts
@@ -11,7 +11,7 @@ import type {
   SectorConfigurationId,
 } from './types';
 
-export {
+export type {
   SectorConfigurationPlanRetrievalRequest,
   SectorConfigurationPlanRetrievalReply,
 } from './types';
@@ -54,7 +54,11 @@ export default function prepareRetrieveSectorConfigurationPlan(
 }
 
 export function knownConfigurationsToMap(
-  knownConfigurations: undefined | null | SafeB2BDeserializedResponse<KnownConfigurations>,
+  knownConfigurations:
+    | undefined
+    | null
+    | SafeB2BDeserializedResponse<KnownConfigurations>
+    | KnownConfigurations,
 ): Map<SectorConfigurationId, AirspaceId[]> {
   if (!knownConfigurations?.item) {
     return new Map();

--- a/src/Flow/types.ts
+++ b/src/Flow/types.ts
@@ -456,7 +456,7 @@ export type ScenarioTrafficVolumeMatchingKind =
   | 'OVERLAPPING_REFERENCE_LOCATION'
   | 'SAME_REFERENCE_LOCATION'
   | 'SAME_TRAFFIC_VOLUME';
-interface IRegulationOrMCDMOnly extends Measure {
+export interface IRegulationOrMCDMOnly extends Measure {
   regulationId: RegulationId;
   reason?: RegulationReason;
   location?: TrafficVolumeLocation;
@@ -673,18 +673,18 @@ export interface OTMVPlans extends TacticalConfigurationPlan {
   >;
 }
 
-interface OTMVPlanForDuration {
+export interface OTMVPlanForDuration {
   nmSchedule?: NMSet<PlannedOTMV>;
   clientSchedule: NMSet<PlannedOTMV>;
 }
 
-interface PlannedOTMV {
+export interface PlannedOTMV {
   applicabilityPeriod: DateTimeMinutePeriod;
   dataSource: PlanDataSource;
   otmv?: OTMV;
 }
 
-interface OTMV {
+export interface OTMV {
   trafficVolume: TrafficVolumeId;
   otmvDuration: DurationHourMinute;
   peak?: OTMVPeak;
@@ -692,17 +692,17 @@ interface OTMV {
   remark?: string;
 }
 
-interface OTMVPeak {
+export interface OTMVPeak {
   threshold: OTMVThreshold;
 }
 
-interface OTMVSustained {
+export interface OTMVSustained {
   threshold: OTMVThreshold;
   crossingOccurrences: number;
   elapsed: DurationHourMinute;
 }
 
-type OTMVThreshold = number;
+export type OTMVThreshold = number;
 
 export type OTMVPlanRetrievalReply = ReplyWithData<OTMVPlanRetrievalReplyData>;
 

--- a/src/Flow/updateCapacityPlan.ts
+++ b/src/Flow/updateCapacityPlan.ts
@@ -9,7 +9,10 @@ import type {
   CapacityPlanUpdateReply,
 } from './types';
 
-export { CapacityPlanUpdateRequest, CapacityPlanUpdateReply } from './types';
+export type {
+  CapacityPlanUpdateRequest,
+  CapacityPlanUpdateReply,
+} from './types';
 
 export type Values = CapacityPlanUpdateRequest;
 export type Result = CapacityPlanUpdateReply;

--- a/src/Flow/updateOTMVPlan.ts
+++ b/src/Flow/updateOTMVPlan.ts
@@ -6,7 +6,7 @@ import { instrument } from '../utils/instrumentation';
 
 import type { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types';
 
-export { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types';
+export type { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types';
 
 export type Values = OTMVPlanUpdateRequest;
 export type Result = OTMVPlanUpdateReply;

--- a/src/GeneralInformation/queryNMB2BWSDLs.ts
+++ b/src/GeneralInformation/queryNMB2BWSDLs.ts
@@ -5,6 +5,7 @@ import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 
 import type { NMB2BWSDLsReply, NMB2BWSDLsRequest } from './types';
+export type { NMB2BWSDLsReply, NMB2BWSDLsRequest };
 
 type Values = NMB2BWSDLsRequest;
 type Result = NMB2BWSDLsReply;

--- a/src/GeneralInformation/retrieveUserinformation.ts
+++ b/src/GeneralInformation/retrieveUserinformation.ts
@@ -5,6 +5,7 @@ import { prepareSerializer } from '../utils/transformers';
 import { instrument } from '../utils/instrumentation';
 
 import type { UserInformationRequest, UserInformationReply } from './types';
+export type { UserInformationRequest, UserInformationReply };
 
 type Values = UserInformationRequest;
 type Result = UserInformationReply;


### PR DESCRIPTION
Export all B2B types

Fix `AUPSummary.notes` type.

Closes #155, #154 