### PR TITLE
Remove unused dotenv import

### DIFF
--- a/.changeset/many-rice-chew.md
+++ b/.changeset/many-rice-chew.md
@@ -1,0 +1,5 @@
+---
+'@dgac/nmb2b-client': patch
+---
+
+Remove unused dotenv/config import from config.ts

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import type { Security } from './security';
 import { isValidSecurity } from './security';
 import type { B2BFlavour } from './constants';


### PR DESCRIPTION
`dotenv/config` is currently imported in src/config.ts

This will break use of this library in packages without `dotenv` installed.