### PR TITLE
Fix failing tests under certain conditions

### DIFF
--- a/.changeset/twelve-coats-try.md
+++ b/.changeset/twelve-coats-try.md
@@ -1,0 +1,5 @@
+---
+'@dgac/nmb2b-client': patch
+---
+
+Fix tests failing when a flight returned by `queryFlightsBy*` has a non ICAO aerodrome of departure or destination

--- a/src/Flight/queryFlightsByAerodrome.test.ts
+++ b/src/Flight/queryFlightsByAerodrome.test.ts
@@ -2,7 +2,7 @@ import { add, sub } from 'date-fns';
 import { makeFlightClient } from '..';
 import b2bOptions from '../../tests/options';
 import { shouldUseRealB2BConnection } from '../../tests/utils';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, assert } from 'vitest';
 
 describe('queryFlightsByAirspace', async () => {
   const Flight = await makeFlightClient(b2bOptions);
@@ -48,17 +48,28 @@ describe('queryFlightsByAirspace', async () => {
 
     expect(res.data.flights).toEqual(expect.any(Array));
 
-    for (const flight of res.data.flights) {
+    for (const flightOrFlightPlan of res.data.flights) {
+      assert('flight' in flightOrFlightPlan && !!flightOrFlightPlan.flight);
+
+      const flight = flightOrFlightPlan.flight;
+      assert(flight.flightId);
+
+      if (!flight.flightId.keys?.aerodromeOfDeparture) {
+        expect(flight.flightId.keys?.nonICAOAerodromeOfDeparture).toBe(true);
+      }
+
+      if (!flight.flightId.keys?.aerodromeOfDestination) {
+        expect(flight.flightId.keys?.nonICAOAerodromeOfDestination).toBe(
+          true,
+        );
+      }
+
       expect(flight).toMatchObject({
-        flight: {
-          flightId: {
-            id: expect.any(String),
-            keys: {
-              aircraftId: expect.any(String),
-              aerodromeOfDeparture: expect.stringMatching(/^[A-Z]{4}$/),
-              aerodromeOfDestination: expect.stringMatching(/^[A-Z]{4}$/),
-              estimatedOffBlockTime: expect.any(Date),
-            },
+        flightId: {
+          id: expect.any(String),
+          keys: {
+            aircraftId: expect.any(String),
+            estimatedOffBlockTime: expect.any(Date),
           },
         },
       });

--- a/src/Flight/queryFlightsByAerodromeSet.test.ts
+++ b/src/Flight/queryFlightsByAerodromeSet.test.ts
@@ -2,7 +2,7 @@ import { makeFlightClient } from '..';
 import { add, sub } from 'date-fns';
 import b2bOptions from '../../tests/options';
 import { shouldUseRealB2BConnection } from '../../tests/utils';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, assert } from 'vitest';
 
 describe('queryFlightsByAirspace', async () => {
   const Flight = await makeFlightClient(b2bOptions);
@@ -48,17 +48,26 @@ describe('queryFlightsByAirspace', async () => {
 
     expect(res.data.flights).toEqual(expect.any(Array));
 
-    for (const flight of res.data.flights) {
+    for (const flightOrFlightPlan of res.data.flights) {
+      assert('flight' in flightOrFlightPlan && !!flightOrFlightPlan.flight);
+
+      const flight = flightOrFlightPlan.flight;
+      assert(flight.flightId);
+
+      if (!flight.flightId.keys?.aerodromeOfDeparture) {
+        expect(flight.flightId.keys?.nonICAOAerodromeOfDeparture).toBe(true);
+      }
+
+      if (!flight.flightId.keys?.aerodromeOfDestination) {
+        expect(flight.flightId.keys?.nonICAOAerodromeOfDestination).toBe(true);
+      }
+
       expect(flight).toMatchObject({
-        flight: {
-          flightId: {
-            id: expect.any(String),
-            keys: {
-              aircraftId: expect.any(String),
-              aerodromeOfDeparture: expect.stringMatching(/^[A-Z]{4}$/),
-              aerodromeOfDestination: expect.stringMatching(/^[A-Z]{4}$/),
-              estimatedOffBlockTime: expect.any(Date),
-            },
+        flightId: {
+          id: expect.any(String),
+          keys: {
+            aircraftId: expect.any(String),
+            estimatedOffBlockTime: expect.any(Date),
           },
         },
       });

--- a/src/Flight/queryFlightsByAirspace.test.ts
+++ b/src/Flight/queryFlightsByAirspace.test.ts
@@ -2,7 +2,7 @@ import { makeFlightClient } from '..';
 import { add, sub } from 'date-fns';
 import b2bOptions from '../../tests/options';
 import { shouldUseRealB2BConnection } from '../../tests/utils';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, assert } from 'vitest';
 
 describe('queryFlightsByAirspace', async () => {
   const Flight = await makeFlightClient(b2bOptions);
@@ -47,17 +47,28 @@ describe('queryFlightsByAirspace', async () => {
 
     expect(res.data.flights).toEqual(expect.any(Array));
 
-    for (const flight of res.data.flights) {
+    for (const flightOrFlightPlan of res.data.flights) {
+      assert('flight' in flightOrFlightPlan && !!flightOrFlightPlan.flight);
+
+      const flight = flightOrFlightPlan.flight;
+      assert(flight.flightId);
+
+      if (!flight.flightId.keys?.aerodromeOfDeparture) {
+        expect(flight.flightId.keys?.nonICAOAerodromeOfDeparture).toBe(true);
+      }
+
+      if (!flight.flightId.keys?.aerodromeOfDestination) {
+        expect(flight.flightId.keys?.nonICAOAerodromeOfDestination).toBe(
+          true,
+        );
+      }
+
       expect(flight).toMatchObject({
-        flight: {
-          flightId: {
-            id: expect.any(String),
-            keys: {
-              aircraftId: expect.any(String),
-              aerodromeOfDeparture: expect.stringMatching(/^[A-Z]{4}$/),
-              aerodromeOfDestination: expect.stringMatching(/^[A-Z]{4}$/),
-              estimatedOffBlockTime: expect.any(Date),
-            },
+        flightId: {
+          id: expect.any(String),
+          keys: {
+            aircraftId: expect.any(String),
+            estimatedOffBlockTime: expect.any(Date),
           },
         },
       });

--- a/src/Flight/queryFlightsByMeasure.test.ts
+++ b/src/Flight/queryFlightsByMeasure.test.ts
@@ -9,7 +9,7 @@ import {
 
 import b2bOptions from '../../tests/options';
 import type { Regulation } from '../Flow/types';
-import { beforeAll, describe, expect, test } from 'vitest';
+import { assert, beforeAll, describe, expect, test } from 'vitest';
 import { shouldUseRealB2BConnection } from '../../tests/utils';
 import { sub, add, startOfHour } from 'date-fns';
 import { extractReferenceLocation } from '../utils';
@@ -89,17 +89,28 @@ describe('queryFlightsByMeasure', async () => {
 
       expect(res.data.flights).toEqual(expect.any(Array));
 
-      for (const flight of res.data.flights) {
+      for (const flightOrFlightPlan of res.data.flights) {
+        assert('flight' in flightOrFlightPlan && !!flightOrFlightPlan.flight);
+
+        const flight = flightOrFlightPlan.flight;
+        assert(flight.flightId);
+
+        if (!flight.flightId.keys?.aerodromeOfDeparture) {
+          expect(flight.flightId.keys?.nonICAOAerodromeOfDeparture).toBe(true);
+        }
+
+        if (!flight.flightId.keys?.aerodromeOfDestination) {
+          expect(flight.flightId.keys?.nonICAOAerodromeOfDestination).toBe(
+            true,
+          );
+        }
+
         expect(flight).toMatchObject({
-          flight: {
-            flightId: {
-              id: expect.any(String),
-              keys: {
-                aircraftId: expect.any(String),
-                aerodromeOfDeparture: expect.stringMatching(/^[A-Z]{4}$/),
-                aerodromeOfDestination: expect.stringMatching(/^[A-Z]{4}$/),
-                estimatedOffBlockTime: expect.any(Date),
-              },
+          flightId: {
+            id: expect.any(String),
+            keys: {
+              aircraftId: expect.any(String),
+              estimatedOffBlockTime: expect.any(Date),
             },
           },
         });


### PR DESCRIPTION
`queryFlightsBy*` tests fail if a flight has either a non ICAO aerodrome of departure or a non ICAO aerodrome of destination.