### PR TITLE
Improve SOAP request input types

### DIFF
--- a/.changeset/beige-pans-speak.md
+++ b/.changeset/beige-pans-speak.md
@@ -1,0 +1,5 @@
+---
+'@dgac/nmb2b-client': minor
+---
+
+Rework B2B input types to accept `Request` parameters (`endUserId`, `onBehalfOfUnit`)

--- a/src/Airspace/queryCompleteAIXMDatasets.ts
+++ b/src/Airspace/queryCompleteAIXMDatasets.ts
@@ -1,6 +1,10 @@
 import type { SoapOptions } from '../soap.js';
 import { instrument } from '../utils/instrumentation/index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import type { AirspaceClient } from './index.js';
 
@@ -14,11 +18,11 @@ export type {
   CompleteAIXMDatasetRequest,
 } from './types.js';
 
-type Values = CompleteAIXMDatasetRequest;
+type Input = InjectSendTime<CompleteAIXMDatasetRequest>;
 type Result = CompleteAIXMDatasetReply;
 
 export type Resolver = (
-  values: CompleteAIXMDatasetRequest,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<CompleteAIXMDatasetReply>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryCompleteAIXMDatasets(
       .queryCompleteAIXMDatasets.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Airspace',
     query: 'queryCompleteAIXMDatasets',
   })(

--- a/src/Airspace/retrieveAUP.ts
+++ b/src/Airspace/retrieveAUP.ts
@@ -1,17 +1,21 @@
 import type { SoapOptions } from '../soap.js';
 import { instrument } from '../utils/instrumentation/index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import type { AirspaceClient } from './index.js';
 
 import type { AUPRetrievalReply, AUPRetrievalRequest } from './types.js';
 export type { AUPRetrievalReply, AUPRetrievalRequest };
 
-type Values = AUPRetrievalRequest;
+type Input = InjectSendTime<AUPRetrievalRequest>;
 type Result = AUPRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -23,7 +27,7 @@ export default function prepareRetrieveAUP(client: AirspaceClient): Resolver {
       .retrieveAUP.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Airspace',
     query: 'retrieveAUP',
   })(

--- a/src/Airspace/retrieveAUPChain.ts
+++ b/src/Airspace/retrieveAUPChain.ts
@@ -1,6 +1,10 @@
 import type { SoapOptions } from '../soap.js';
 import { instrument } from '../utils/instrumentation/index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import type { AirspaceClient } from './index.js';
 import type {
@@ -9,11 +13,11 @@ import type {
 } from './types.js';
 export type { AUPChainRetrievalReply, AUPChainRetrievalRequest };
 
-type Values = AUPChainRetrievalRequest;
+type Input = InjectSendTime<AUPChainRetrievalRequest>;
 type Result = AUPChainRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -27,7 +31,7 @@ export default function prepareRetrieveAUPChain(
       .retrieveAUPChain.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Airspace',
     query: 'retrieveAUPChain',
   })(

--- a/src/Airspace/retrieveEAUPChain.ts
+++ b/src/Airspace/retrieveEAUPChain.ts
@@ -1,6 +1,10 @@
 import type { SoapOptions } from '../soap.js';
 import { instrument } from '../utils/instrumentation/index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import type { AirspaceClient } from './index.js';
 import type {
@@ -10,11 +14,11 @@ import type {
 
 export type { EAUPChainRetrievalReply, EAUPChainRetrievalRequest };
 
-type Values = EAUPChainRetrievalRequest;
+type Input = InjectSendTime<EAUPChainRetrievalRequest>;
 type Result = EAUPChainRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -28,7 +32,7 @@ export default function prepareRetrieveEAUPChain(
       .retrieveEAUPChain.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Airspace',
     query: 'retrieveEAUPChain',
   })(

--- a/src/Airspace/types.ts
+++ b/src/Airspace/types.ts
@@ -1,5 +1,6 @@
 import type {
   AirNavigationUnitId,
+  B2BRequest,
   Bearing,
   DateTimeMinute,
   DateTimeMinutePeriod,
@@ -307,7 +308,7 @@ export interface FlightLevelRange {
   max: FlightLevel;
 }
 
-export type CompleteAIXMDatasetRequest = {
+export type CompleteAIXMDatasetRequest = B2BRequest & {
   queryCriteria: CompleteDatasetQueryCriteria;
 };
 
@@ -315,7 +316,7 @@ export type CompleteAIXMDatasetReply = ReplyWithData<{
   datasetSummaries: CompleteDatasetSummary[];
 }>;
 
-export type AUPRetrievalRequest = {
+export type AUPRetrievalRequest = B2BRequest & {
   aupId: AUPId;
   returnComputed?: boolean;
 };
@@ -324,7 +325,7 @@ export type AUPRetrievalReply = ReplyWithData<{
   aup: AUP;
 }>;
 
-export type AUPChainRetrievalRequest = {
+export type AUPChainRetrievalRequest = B2BRequest & {
   chainDate: DateYearMonthDay;
   amcIds?: AirNavigationUnitId[];
 };
@@ -333,7 +334,7 @@ export type AUPChainRetrievalReply = ReplyWithData<{
   chains: AUPChain[];
 }>;
 
-export type EAUPChainRetrievalRequest = {
+export type EAUPChainRetrievalRequest = B2BRequest & {
   chainDate: DateYearMonthDay;
 };
 

--- a/src/Common/types.ts
+++ b/src/Common/types.ts
@@ -146,7 +146,7 @@ export type ReplyWithData<TData = never> = Reply & {
   data: SoapDeserializer<TData>;
 };
 
-export type Request = {
+export type B2BRequest = {
   endUserId?: string;
   onBehalfOfUnit?: AirNavigationUnitId;
   sendTime: DateTimeSecond;

--- a/src/Flight/queryFlightPlans.ts
+++ b/src/Flight/queryFlightPlans.ts
@@ -1,16 +1,20 @@
 import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
 import type { FlightPlanListRequest, FlightPlanListReply } from './types.js';
 export type { FlightPlanListRequest, FlightPlanListReply } from './types.js';
 
-type Values = FlightPlanListRequest;
+type Input = InjectSendTime<FlightPlanListRequest>;
 type Result = FlightPlanListReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -24,7 +28,7 @@ export default function prepareQueryFlightPlans(
       .queryFlightPlans.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightPlans',
   })(

--- a/src/Flight/queryFlightsByAerodrome.ts
+++ b/src/Flight/queryFlightsByAerodrome.ts
@@ -1,24 +1,28 @@
-import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
+import { prepareSerializer } from '../utils/transformers/index.js';
+import type { FlightClient } from './index.js';
 
 import type {
-  FlightListByAerodromeRequest,
   FlightListByAerodromeReply,
+  FlightListByAerodromeRequest,
 } from './types.js';
 
 export type {
-  FlightListByAerodromeRequest,
   FlightListByAerodromeReply,
+  FlightListByAerodromeRequest,
 } from './types.js';
 
-type Values = FlightListByAerodromeRequest;
+type Input = InjectSendTime<FlightListByAerodromeRequest>;
 type Result = FlightListByAerodromeReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryFlightsByAerodrome(
       .queryFlightsByAerodrome.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightsByAerodrome',
   })(

--- a/src/Flight/queryFlightsByAerodromeSet.ts
+++ b/src/Flight/queryFlightsByAerodromeSet.ts
@@ -1,24 +1,28 @@
-import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
+import { prepareSerializer } from '../utils/transformers/index.js';
+import type { FlightClient } from './index.js';
 
 import type {
-  FlightListByAerodromeSetRequest,
   FlightListByAerodromeSetReply,
+  FlightListByAerodromeSetRequest,
 } from './types.js';
 
 export type {
-  FlightListByAerodromeSetRequest,
   FlightListByAerodromeSetReply,
+  FlightListByAerodromeSetRequest,
 } from './types.js';
 
-type Values = FlightListByAerodromeSetRequest;
+type Input = InjectSendTime<FlightListByAerodromeSetRequest>;
 type Result = FlightListByAerodromeSetReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryFlightsByAerodromeSet(
       .queryFlightsByAerodromeSet.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightsByAerodromeSet',
   })(

--- a/src/Flight/queryFlightsByAircraftOperator.ts
+++ b/src/Flight/queryFlightsByAircraftOperator.ts
@@ -1,5 +1,9 @@
 import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   FlightListByAircraftOperatorReply,
 } from './types.js';
 
-type Values = FlightListByAircraftOperatorRequest;
+type Input = InjectSendTime<FlightListByAircraftOperatorRequest>;
 type Result = FlightListByAircraftOperatorReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryFlightsByAircraftOperator(
       .queryFlightsByAircraftOperator.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightsByAircraftOperator',
   })(

--- a/src/Flight/queryFlightsByAirspace.ts
+++ b/src/Flight/queryFlightsByAirspace.ts
@@ -1,5 +1,9 @@
 import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   FlightListByAirspaceReply,
 } from './types.js';
 
-type Values = FlightListByAirspaceRequest;
+type Input = InjectSendTime<FlightListByAirspaceRequest>;
 type Result = FlightListByAirspaceReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryFlightsByAirspace(
       .queryFlightsByAirspace.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightsByAirspace',
   })(

--- a/src/Flight/queryFlightsByMeasure.ts
+++ b/src/Flight/queryFlightsByMeasure.ts
@@ -1,5 +1,9 @@
 import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   FlightListByMeasureReply,
 } from './types.js';
 
-type Values = FlightListByMeasureRequest;
+type Input = InjectSendTime<FlightListByMeasureRequest>;
 type Result = FlightListByMeasureReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryFlightsByMeasure(
       .queryFlightsByMeasure.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightsByMeasure',
   })(

--- a/src/Flight/queryFlightsByTrafficVolume.ts
+++ b/src/Flight/queryFlightsByTrafficVolume.ts
@@ -1,5 +1,9 @@
 import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   FlightListByTrafficVolumeReply,
 } from './types.js';
 
-type Values = FlightListByTrafficVolumeRequest;
+type Input = InjectSendTime<FlightListByTrafficVolumeRequest>;
 type Result = FlightListByTrafficVolumeReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryFlightsByTrafficVolume(
       .queryFlightsByTrafficVolume.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'queryFlightsByTrafficVolume',
   })(

--- a/src/Flight/retrieveFlight.ts
+++ b/src/Flight/retrieveFlight.ts
@@ -1,5 +1,9 @@
 import type { FlightClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -7,11 +11,11 @@ import { instrument } from '../utils/instrumentation/index.js';
 import type { FlightRetrievalRequest, FlightRetrievalReply } from './types.js';
 export type { FlightRetrievalRequest, FlightRetrievalReply } from './types.js';
 
-type Values = FlightRetrievalRequest;
+type Input = InjectSendTime<FlightRetrievalRequest>;
 type Result = FlightRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -23,7 +27,7 @@ export default function prepareRetrieveFlight(client: FlightClient): Resolver {
       .retrieveFlight.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flight',
     query: 'retrieveFlight',
   })(

--- a/src/Flight/types.ts
+++ b/src/Flight/types.ts
@@ -22,6 +22,7 @@ import type {
 
 import type {
   AirNavigationUnitId,
+  B2BRequest,
   Colours,
   Cost,
   Dataset,
@@ -1274,7 +1275,7 @@ export interface ActualTimeAtTarget {
 }
 export type IntervalPosition = 'AFTER' | 'BEFORE' | 'INSIDE';
 
-export type FlightListRequest = {
+export type FlightListRequest = B2BRequest & {
   dataset: Dataset;
   includeProposalFlights: boolean;
   includeForecastFlights: boolean;
@@ -1363,7 +1364,7 @@ export type FlightListByAirspaceReply =
 export interface FlightListByAirspaceReplyData
   extends FlightListByLocationReplyData {}
 
-export type FlightPlanListRequest = {
+export type FlightPlanListRequest = B2BRequest & {
   aircraftId?: string;
   aerodromeOfDeparture?: string;
   nonICAOAerodromeOfDeparture: boolean;
@@ -1379,7 +1380,7 @@ export type FlightPlanListReplyData = {
   summaries: FlightPlanOrInvalidFiling[];
 };
 
-export type FlightRetrievalRequest = {
+export type FlightRetrievalRequest = B2BRequest & {
   dataset: Dataset;
   includeProposalFlights: boolean;
   flightId: FlightIdentificationInput;

--- a/src/Flow/queryHotspots.ts
+++ b/src/Flow/queryHotspots.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -7,11 +11,11 @@ import { instrument } from '../utils/instrumentation/index.js';
 import type { HotspotListRequest, HotspotListReply } from './types.js';
 export type { HotspotListRequest, HotspotListReply } from './types.js';
 
-type Values = HotspotListRequest;
+type Input = InjectSendTime<HotspotListRequest>;
 type Result = HotspotListReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -23,7 +27,7 @@ export default function prepareQueryHotspots(client: FlowClient): Resolver {
       .input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'queryHotspots',
   })(

--- a/src/Flow/queryRegulations.ts
+++ b/src/Flow/queryRegulations.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -7,11 +11,11 @@ import { instrument } from '../utils/instrumentation/index.js';
 import type { RegulationListRequest, RegulationListReply } from './types.js';
 export type { RegulationListRequest, RegulationListReply } from './types.js';
 
-type Values = RegulationListRequest;
+type Input = InjectSendTime<RegulationListRequest>;
 type Result = RegulationListReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -22,7 +26,7 @@ export default function prepareQueryRegulations(client: FlowClient): Resolver {
     client.describe().MeasuresService.MeasuresPort.queryRegulations.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'queryRegulations',
   })(

--- a/src/Flow/queryTrafficCountsByAirspace.ts
+++ b/src/Flow/queryTrafficCountsByAirspace.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   TrafficCountsByAirspaceReply,
 } from './types.js';
 
-type Values = TrafficCountsByAirspaceRequest;
+type Input = InjectSendTime<TrafficCountsByAirspaceRequest>;
 type Result = TrafficCountsByAirspaceReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryTrafficCountsByAirspace(
       .queryTrafficCountsByAirspace.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'queryTrafficCountsByAirspace',
   })(

--- a/src/Flow/queryTrafficCountsByTrafficVolume.ts
+++ b/src/Flow/queryTrafficCountsByTrafficVolume.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   TrafficCountsByTrafficVolumeReply,
 } from './types.js';
 
-type Values = TrafficCountsByTrafficVolumeRequest;
+type Input = InjectSendTime<TrafficCountsByTrafficVolumeRequest>;
 type Result = TrafficCountsByTrafficVolumeReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareQueryTrafficCountsByTrafficVolume(
       .queryTrafficCountsByTrafficVolume.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'queryTrafficCountsByTrafficVolume',
   })(

--- a/src/Flow/retrieveCapacityPlan.test.ts
+++ b/src/Flow/retrieveCapacityPlan.test.ts
@@ -3,14 +3,13 @@ import { assert, describe, expect, test } from 'vitest';
 import b2bOptions from '../../tests/options.js';
 import { shouldUseRealB2BConnection } from '../../tests/utils.js';
 import { NMB2BError, createFlowClient } from '../index.js';
-import type { Result as CapacityPlanRetrievalResult } from './retrieveCapacityPlan.js';
 
 describe('retrieveCapacityPlan', async () => {
   const Flow = await createFlowClient(b2bOptions);
 
   test.runIf(shouldUseRealB2BConnection)('LFERMS, LFBBDX', async () => {
     try {
-      const res: CapacityPlanRetrievalResult = await Flow.retrieveCapacityPlan({
+      const res = await Flow.retrieveCapacityPlan({
         dataset: { type: 'OPERATIONAL' },
         day: new Date(),
         trafficVolumes: {

--- a/src/Flow/retrieveCapacityPlan.ts
+++ b/src/Flow/retrieveCapacityPlan.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   CapacityPlanRetrievalReply,
 } from './types.js';
 
-export type Values = CapacityPlanRetrievalRequest;
-export type Result = CapacityPlanRetrievalReply;
+type Input = InjectSendTime<CapacityPlanRetrievalRequest>;
+type Result = CapacityPlanRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareRetrieveCapacityPlan(
       .retrieveCapacityPlan.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'retrieveCapacityPlan',
   })(

--- a/src/Flow/retrieveOTMVPlan.ts
+++ b/src/Flow/retrieveOTMVPlan.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -13,11 +17,11 @@ export type {
   OTMVPlanRetrievalReply,
 } from './types.js';
 
-export type Values = OTMVPlanRetrievalRequest;
-export type Result = OTMVPlanRetrievalReply;
+type Input = InjectSendTime<OTMVPlanRetrievalRequest>;
+type Result = OTMVPlanRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -30,7 +34,7 @@ export default function prepareRetrieveOTMVPlan(client: FlowClient): Resolver {
 
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'retrieveOTMVPlan',
   })(

--- a/src/Flow/retrieveRunwayConfigurationPlan.ts
+++ b/src/Flow/retrieveRunwayConfigurationPlan.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   RunwayConfigurationPlanRetrievalReply,
 } from './types.js';
 
-export type Values = RunwayConfigurationPlanRetrievalRequest;
-export type Result = RunwayConfigurationPlanRetrievalReply;
+type Input = InjectSendTime<RunwayConfigurationPlanRetrievalRequest>;
+type Result = RunwayConfigurationPlanRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -32,7 +36,7 @@ export default function prepareRetrieveRunwayConfigurationPlan(
       .retrieveRunwayConfigurationPlan.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'retrieveRunwayConfigurationPlan',
   })(

--- a/src/Flow/retrieveSectorConfigurationPlan.ts
+++ b/src/Flow/retrieveSectorConfigurationPlan.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -19,11 +23,11 @@ export type {
   SectorConfigurationPlanRetrievalReply,
 } from './types.js';
 
-type Values = SectorConfigurationPlanRetrievalRequest;
+type Input = InjectSendTime<SectorConfigurationPlanRetrievalRequest>;
 type Result = SectorConfigurationPlanRetrievalReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -37,7 +41,7 @@ export default function prepareRetrieveSectorConfigurationPlan(
       .retrieveSectorConfigurationPlan.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'retrieveSectorConfigurationPlan',
   })(

--- a/src/Flow/types.ts
+++ b/src/Flow/types.ts
@@ -14,6 +14,7 @@ import type {
 
 import type {
   AirNavigationUnitId,
+  B2BRequest,
   Dataset,
   DateTimeMinute,
   DateTimeMinutePeriod,
@@ -200,7 +201,7 @@ export type SectorConfigurationPlanRetrievalRequest =
     airspace: AirspaceId;
   };
 
-export type TacticalConfigurationRetrievalRequest = {
+export type TacticalConfigurationRetrievalRequest = B2BRequest & {
   dataset: Dataset;
   day: DateYearMonthDay;
 };
@@ -255,7 +256,7 @@ export type TrafficCountsByTrafficVolumeRequest = TrafficCountsRequest & {
   includeInvisibleFlights?: boolean;
 };
 
-export type TrafficCountsRequest = {
+export type TrafficCountsRequest = B2BRequest & {
   dataset: Dataset;
   trafficWindow: DateTimeMinutePeriod;
   includeProposalFlights: boolean;
@@ -434,7 +435,7 @@ export type RegulationOrMCDMOnlyListRequest = MeasureListRequest & {
   reasons?: NMSet<RegulationReason>;
 };
 
-export type MeasureListRequest = {
+export type MeasureListRequest = B2BRequest & {
   dataset: Dataset;
   queryPeriod: DateTimeMinutePeriod;
   tvs?: NMSet<TrafficVolumeIdWildcard>;
@@ -633,7 +634,7 @@ export interface RegulationOccupancyConstraint {
   pendingCapacityPercentage: number;
 }
 
-export type HotspotListRequest = {
+export type HotspotListRequest = B2BRequest & {
   dataset: Dataset;
   day: DateYearMonthDay;
   trafficVolume?: TrafficVolumeId;
@@ -709,7 +710,7 @@ export interface OTMVPlanRetrievalReplyData {
   plans: OTMVPlans;
 }
 
-export type OTMVPlanUpdateRequest = {
+export type OTMVPlanUpdateRequest = B2BRequest & {
   plans: OTMVPlans;
 };
 
@@ -748,7 +749,7 @@ export interface PlannedCapacity {
 
 export type Capacity = number;
 
-export type CapacityPlanUpdateRequest = {
+export type CapacityPlanUpdateRequest = B2BRequest & {
   plans: CapacityPlans;
 };
 

--- a/src/Flow/updateCapacityPlan.test.ts
+++ b/src/Flow/updateCapacityPlan.test.ts
@@ -3,23 +3,19 @@ import { inspect } from 'util';
 import { describe, expect, test } from 'vitest';
 import b2bOptions from '../../tests/options.js';
 import { NMB2BError, createFlowClient } from '../index.js';
-import type { Result as CapacityPlanRetrievalResult } from './retrieveCapacityPlan.js';
-import type { Result as CapacityPlanUpdateResult } from './updateCapacityPlan.js';
 
 describe('updateCapacityPlan', async () => {
   const Flow = await createFlowClient(b2bOptions);
 
   test.skip('LFERMS', async () => {
     try {
-      const plan: CapacityPlanRetrievalResult = await Flow.retrieveCapacityPlan(
-        {
-          dataset: { type: 'OPERATIONAL' },
-          day: new Date(),
-          trafficVolumes: {
-            item: ['LFERMS'],
-          },
+      const plan = await Flow.retrieveCapacityPlan({
+        dataset: { type: 'OPERATIONAL' },
+        day: new Date(),
+        trafficVolumes: {
+          item: ['LFERMS'],
         },
-      );
+      });
 
       expect(plan.data).toBeDefined();
 
@@ -29,7 +25,7 @@ describe('updateCapacityPlan', async () => {
       }
 
       const hPlus10Min = add(new Date(), { minutes: 10 });
-      const res: CapacityPlanUpdateResult = await Flow.updateCapacityPlan({
+      const res = await Flow.updateCapacityPlan({
         plans: {
           dataId: plan.data.plans.dataId,
           dataset: { type: 'OPERATIONAL' },

--- a/src/Flow/updateCapacityPlan.ts
+++ b/src/Flow/updateCapacityPlan.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -14,11 +18,11 @@ export type {
   CapacityPlanUpdateReply,
 } from './types.js';
 
-export type Values = CapacityPlanUpdateRequest;
-export type Result = CapacityPlanUpdateReply;
+type Input = InjectSendTime<CapacityPlanUpdateRequest>;
+type Result = CapacityPlanUpdateReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -33,7 +37,7 @@ export default function prepareUpdateCapacityPlan(
 
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'updateCapacityPlan',
   })(

--- a/src/Flow/updateOTMVPlan.test.ts
+++ b/src/Flow/updateOTMVPlan.test.ts
@@ -3,13 +3,12 @@ import { add, startOfDay } from 'date-fns';
 import { afterAll, assert, beforeAll, describe, expect, test } from 'vitest';
 import b2bOptions from '../../tests/options.js';
 import { createFlowClient } from '../index.js';
-import type { Result as OTMVPlanRetrievalResult } from './retrieveOTMVPlan.js';
-import type { Result as OTMVPlanUpdateResult } from './updateOTMVPlan.js';
+import type { OTMVPlanRetrievalReply } from './types.js';
 
 describe('updateOTMVPlan', async () => {
   const Flow = await createFlowClient(b2bOptions);
 
-  let planBefore: OTMVPlanRetrievalResult['data'] | undefined;
+  let planBefore: OTMVPlanRetrievalReply['data'] | undefined;
 
   beforeAll(async () => {
     const res = await Flow.retrieveOTMVPlan({
@@ -75,7 +74,7 @@ describe('updateOTMVPlan', async () => {
 
       const hPlus10Min = add(new Date(), { minutes: 10 });
 
-      const res: OTMVPlanUpdateResult = await Flow.updateOTMVPlan({
+      const res = await Flow.updateOTMVPlan({
         plans: {
           dataId: planBefore.plans.dataId,
           dataset: { type: 'OPERATIONAL' },

--- a/src/Flow/updateOTMVPlan.ts
+++ b/src/Flow/updateOTMVPlan.ts
@@ -1,5 +1,9 @@
 import type { FlowClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -8,11 +12,11 @@ import type { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types.js';
 
 export type { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types.js';
 
-export type Values = OTMVPlanUpdateRequest;
-export type Result = OTMVPlanUpdateReply;
+type Input = InjectSendTime<OTMVPlanUpdateRequest>;
+type Result = OTMVPlanUpdateReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -24,7 +28,7 @@ export default function prepareUpdateOTMVPlan(client: FlowClient): Resolver {
       .input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'Flow',
     query: 'updateOTMVPlan',
   })(

--- a/src/GeneralInformation/queryNMB2BWSDLs.ts
+++ b/src/GeneralInformation/queryNMB2BWSDLs.ts
@@ -1,5 +1,9 @@
 import type { GeneralInformationServiceClient } from './index.js';
-import { injectSendTime, responseStatusHandler } from '../utils/internals.js';
+import {
+  injectSendTime,
+  responseStatusHandler,
+  type InjectSendTime,
+} from '../utils/internals.js';
 import type { SoapOptions } from '../soap.js';
 import { prepareSerializer } from '../utils/transformers/index.js';
 import { instrument } from '../utils/instrumentation/index.js';
@@ -7,11 +11,11 @@ import { instrument } from '../utils/instrumentation/index.js';
 import type { NMB2BWSDLsReply, NMB2BWSDLsRequest } from './types.js';
 export type { NMB2BWSDLsReply, NMB2BWSDLsRequest };
 
-type Values = NMB2BWSDLsRequest;
+type Input = InjectSendTime<NMB2BWSDLsRequest>;
 type Result = NMB2BWSDLsReply;
 
 export type Resolver = (
-  values: Values,
+  values: Input,
   options?: SoapOptions,
 ) => Promise<Result>;
 
@@ -24,15 +28,14 @@ export default function prepareQueryNMB2BWSDLs(
     client.describe().NMB2BInfoService.NMB2BInfoPort.queryNMB2BWSDLs.input;
   const serializer = prepareSerializer(schema);
 
-  return instrument<Values, Result>({
+  return instrument<Input, Result>({
     service: 'GeneralInformation',
     query: 'queryNMB2BWSDLs',
   })((values, options) => {
-    const foo = injectSendTime(values);
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       client.queryNMB2BWSDLs(
-        serializer(foo),
+        serializer(injectSendTime(values)),
         options,
         responseStatusHandler(resolve, reject),
       );

--- a/src/GeneralInformation/types.ts
+++ b/src/GeneralInformation/types.ts
@@ -1,6 +1,11 @@
-import type { File, NMB2BVersion, ReplyWithData } from '../Common/types.js';
+import type {
+  B2BRequest,
+  File,
+  NMB2BVersion,
+  ReplyWithData,
+} from '../Common/types.js';
 
-export type NMB2BWSDLsRequest = {
+export type NMB2BWSDLsRequest = B2BRequest & {
   version: NMB2BVersion;
 };
 
@@ -14,7 +19,7 @@ export interface B2BInfoFile extends File {
   hasAddendaErrata?: boolean;
 }
 
-export type UserInformationRequest = Record<string, never>;
+export type UserInformationRequest = Record<string, never> & B2BRequest;
 
 export type UserInformationReply = ReplyWithData<UserInformationReplyData>;
 

--- a/src/utils/instrumentation/index.ts
+++ b/src/utils/instrumentation/index.ts
@@ -4,7 +4,7 @@ import { withLog } from './withLog.js';
 import { pipe } from 'remeda';
 
 type SoapQuery<Input, Output> = (
-  input?: Input,
+  input: Input,
   options?: SoapOptions,
 ) => Promise<Output>;
 

--- a/src/utils/internals.ts
+++ b/src/utils/internals.ts
@@ -1,18 +1,15 @@
-import type { Reply, ReplyStatus, Request } from '../Common/types.js';
+import type { SetOptional } from 'type-fest';
+import type { B2BRequest, Reply, ReplyStatus } from '../Common/types.js';
 import { NMB2BError } from './NMB2BError.js';
 
-export function injectSendTime<T extends Record<string, unknown>>(
+export type InjectSendTime<T extends B2BRequest> = SetOptional<T, 'sendTime'>;
+
+export function injectSendTime<T extends InjectSendTime<B2BRequest>>(
   values: T,
-): T & Request;
-export function injectSendTime<T extends Record<string, unknown>>(
-  values: T | undefined,
-): Request | (Request & T);
-export function injectSendTime<T extends Record<string, unknown> | undefined>(
-  values: T,
-) {
+): T & { sendTime: Date } {
   const sendTime = new Date();
 
-  return Object.assign({}, values ?? {}, { sendTime });
+  return { sendTime, ...values };
 }
 
 type Cb = (...args: any[]) => void;


### PR DESCRIPTION
All APIs input types are now derived from `B2BRequest` which accepts `endUserId` and `onBehalfOfUnit` properties.