### PR TITLE
Implement new declarative API for wrapped soap services/functions

### DIFF
--- a/.changeset/bitter-dancers-sink.md
+++ b/.changeset/bitter-dancers-sink.md
@@ -1,0 +1,5 @@
+---
+'@dgac/nmb2b-client': patch
+---
+
+Refactor internals with a declarative API which makes it easier to implement new Request/Reply queries

--- a/src/Airspace/index.ts
+++ b/src/Airspace/index.ts
@@ -1,6 +1,6 @@
 import type { Config } from '../config.js';
 import {
-  createService,
+  createSoapService,
   type SoapService,
 } from '../utils/soap-query-definition.js';
 import { queryCompleteAIXMDatasets } from './queryCompleteAIXMDatasets.js';
@@ -20,7 +20,7 @@ export type AirspaceService = SoapService<typeof queryDefinitions>;
 export async function getAirspaceClient(
   config: Config,
 ): Promise<AirspaceService> {
-  const service = await createService({
+  const service = await createSoapService({
     serviceName: 'AirspaceServices',
     config,
     queryDefinitions,

--- a/src/Airspace/index.ts
+++ b/src/Airspace/index.ts
@@ -1,49 +1,30 @@
-import { createClientAsync, type Client as SoapClient } from 'soap';
 import type { Config } from '../config.js';
-import { getWSDLPath } from '../constants.js';
-import { prepareSecurity } from '../security.js';
-import { deserializer as customDeserializer } from '../utils/transformers/index.js';
+import {
+  createService,
+  type SoapService,
+} from '../utils/soap-query-definition.js';
+import { queryCompleteAIXMDatasets } from './queryCompleteAIXMDatasets.js';
+import { retrieveAUP } from './retrieveAUP.js';
+import { retrieveAUPChain } from './retrieveAUPChain.js';
+import { retrieveEAUPChain } from './retrieveEAUPChain.js';
 
-import type { Resolver as QueryCompleteAIXMDatasets } from './queryCompleteAIXMDatasets.js';
-import queryCompleteAIXMDatasets from './queryCompleteAIXMDatasets.js';
-import type { Resolver as RetrieveAUP } from './retrieveAUP.js';
-import retrieveAUP from './retrieveAUP.js';
-import type { Resolver as RetrieveAUPChain } from './retrieveAUPChain.js';
-import retrieveAUPChain from './retrieveAUPChain.js';
-import type { Resolver as RetrieveEAUPChain } from './retrieveEAUPChain.js';
-import retrieveEAUPChain from './retrieveEAUPChain.js';
+const queryDefinitions = {
+  queryCompleteAIXMDatasets,
+  retrieveAUP,
+  retrieveAUPChain,
+  retrieveEAUPChain,
+};
 
-import type { BaseServiceInterface } from '../Common/ServiceInterface.js';
-
-export type AirspaceClient = SoapClient;
-
-export interface AirspaceService extends BaseServiceInterface {
-  queryCompleteAIXMDatasets: QueryCompleteAIXMDatasets;
-  retrieveAUPChain: RetrieveAUPChain;
-  retrieveEAUPChain: RetrieveEAUPChain;
-  retrieveAUP: RetrieveAUP;
-}
+export type AirspaceService = SoapService<typeof queryDefinitions>;
 
 export async function getAirspaceClient(
   config: Config,
 ): Promise<AirspaceService> {
-  const WSDL = getWSDLPath({
-    service: 'AirspaceServices',
-    flavour: config.flavour,
-    XSD_PATH: config.XSD_PATH,
+  const service = await createService({
+    serviceName: 'AirspaceServices',
+    config,
+    queryDefinitions,
   });
 
-  const security = prepareSecurity(config);
-
-  const client = await createClientAsync(WSDL, { customDeserializer });
-  client.setSecurity(security);
-
-  return {
-    __soapClient: client,
-    config,
-    queryCompleteAIXMDatasets: queryCompleteAIXMDatasets(client),
-    retrieveAUPChain: retrieveAUPChain(client),
-    retrieveEAUPChain: retrieveEAUPChain(client),
-    retrieveAUP: retrieveAUP(client),
-  };
+  return service;
 }

--- a/src/Airspace/queryCompleteAIXMDatasets.ts
+++ b/src/Airspace/queryCompleteAIXMDatasets.ts
@@ -14,6 +14,4 @@ export const queryCompleteAIXMDatasets = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceStructureService.AirspaceStructurePort
       .queryCompleteAIXMDatasets.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryCompleteAIXMDatasetsAsync,
 });

--- a/src/Airspace/queryCompleteAIXMDatasets.ts
+++ b/src/Airspace/queryCompleteAIXMDatasets.ts
@@ -1,53 +1,19 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { AirspaceClient } from './index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   CompleteAIXMDatasetReply,
   CompleteAIXMDatasetRequest,
 } from './types.js';
 
-export type {
-  CompleteAIXMDatasetReply,
+export const queryCompleteAIXMDatasets = createSoapQueryDefinition<
   CompleteAIXMDatasetRequest,
-} from './types.js';
-
-type Input = InjectSendTime<CompleteAIXMDatasetRequest>;
-type Result = CompleteAIXMDatasetReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<CompleteAIXMDatasetReply>;
-
-export default function prepareQueryCompleteAIXMDatasets(
-  client: AirspaceClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  CompleteAIXMDatasetReply
+>({
+  service: 'Airspace',
+  query: 'queryCompleteAIXMDatasets',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceStructureService.AirspaceStructurePort
-      .queryCompleteAIXMDatasets.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Airspace',
-    query: 'queryCompleteAIXMDatasets',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryCompleteAIXMDatasets(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryCompleteAIXMDatasets.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryCompleteAIXMDatasetsAsync,
+});

--- a/src/Airspace/retrieveAUP.ts
+++ b/src/Airspace/retrieveAUP.ts
@@ -1,44 +1,16 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { AirspaceClient } from './index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type { AUPRetrievalReply, AUPRetrievalRequest } from './types.js';
-export type { AUPRetrievalReply, AUPRetrievalRequest };
 
-type Input = InjectSendTime<AUPRetrievalRequest>;
-type Result = AUPRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveAUP(client: AirspaceClient): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const retrieveAUP = createSoapQueryDefinition<
+  AUPRetrievalRequest,
+  AUPRetrievalReply
+>({
+  service: 'Airspace',
+  query: 'retrieveAUP',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceAvailabilityService.AirspaceAvailabilityPort
-      .retrieveAUP.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Airspace',
-    query: 'retrieveAUP',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveAUP(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveAUP.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.retrieveAUPAsync,
+});

--- a/src/Airspace/retrieveAUP.ts
+++ b/src/Airspace/retrieveAUP.ts
@@ -11,6 +11,4 @@ export const retrieveAUP = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceAvailabilityService.AirspaceAvailabilityPort
       .retrieveAUP.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.retrieveAUPAsync,
 });

--- a/src/Airspace/retrieveAUPChain.ts
+++ b/src/Airspace/retrieveAUPChain.ts
@@ -1,48 +1,19 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { AirspaceClient } from './index.js';
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   AUPChainRetrievalReply,
   AUPChainRetrievalRequest,
 } from './types.js';
-export type { AUPChainRetrievalReply, AUPChainRetrievalRequest };
 
-type Input = InjectSendTime<AUPChainRetrievalRequest>;
-type Result = AUPChainRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveAUPChain(
-  client: AirspaceClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const retrieveAUPChain = createSoapQueryDefinition<
+  AUPChainRetrievalRequest,
+  AUPChainRetrievalReply
+>({
+  service: 'Airspace',
+  query: 'retrieveAUPChain',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceAvailabilityService.AirspaceAvailabilityPort
-      .retrieveAUPChain.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Airspace',
-    query: 'retrieveAUPChain',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveAUPChain(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveAUPChain.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.retrieveAUPChainAsync,
+});

--- a/src/Airspace/retrieveAUPChain.ts
+++ b/src/Airspace/retrieveAUPChain.ts
@@ -14,6 +14,4 @@ export const retrieveAUPChain = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceAvailabilityService.AirspaceAvailabilityPort
       .retrieveAUPChain.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.retrieveAUPChainAsync,
 });

--- a/src/Airspace/retrieveEAUPChain.ts
+++ b/src/Airspace/retrieveEAUPChain.ts
@@ -14,6 +14,4 @@ export const retrieveEAUPChain = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceAvailabilityService.AirspaceAvailabilityPort
       .retrieveEAUPChain.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.retrieveEAUPChainAsync,
 });

--- a/src/Airspace/retrieveEAUPChain.ts
+++ b/src/Airspace/retrieveEAUPChain.ts
@@ -1,49 +1,19 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { AirspaceClient } from './index.js';
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   EAUPChainRetrievalReply,
   EAUPChainRetrievalRequest,
 } from './types.js';
 
-export type { EAUPChainRetrievalReply, EAUPChainRetrievalRequest };
-
-type Input = InjectSendTime<EAUPChainRetrievalRequest>;
-type Result = EAUPChainRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveEAUPChain(
-  client: AirspaceClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const retrieveEAUPChain = createSoapQueryDefinition<
+  EAUPChainRetrievalRequest,
+  EAUPChainRetrievalReply
+>({
+  service: 'Airspace',
+  query: 'retrieveEAUPChain',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().AirspaceAvailabilityService.AirspaceAvailabilityPort
-      .retrieveEAUPChain.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Airspace',
-    query: 'retrieveEAUPChain',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveEAUPChain(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveEAUPChain.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.retrieveEAUPChainAsync,
+});

--- a/src/Flight/index.ts
+++ b/src/Flight/index.ts
@@ -1,6 +1,6 @@
 import type { Config } from '../config.js';
 import {
-  createService,
+  createSoapService,
   type SoapService,
 } from '../utils/soap-query-definition.js';
 
@@ -27,7 +27,7 @@ const queryDefinitions = {
 export type FlightService = SoapService<typeof queryDefinitions>;
 
 export async function getFlightClient(config: Config): Promise<FlightService> {
-  const service = await createService({
+  const service = await createSoapService({
     serviceName: 'FlightServices',
     config,
     queryDefinitions,

--- a/src/Flight/index.ts
+++ b/src/Flight/index.ts
@@ -1,69 +1,37 @@
-import { type Client as SoapClient, createClientAsync } from 'soap';
 import type { Config } from '../config.js';
-import { getWSDLPath } from '../constants.js';
-import { prepareSecurity } from '../security.js';
-import { deserializer as customDeserializer } from '../utils/transformers/index.js';
+import {
+  createService,
+  type SoapService,
+} from '../utils/soap-query-definition.js';
 
-import type { Resolver as RetrieveFlight } from './retrieveFlight.js';
-import retrieveFlight from './retrieveFlight.js';
+import { queryFlightPlans } from './queryFlightPlans.js';
+import { queryFlightsByAerodrome } from './queryFlightsByAerodrome.js';
+import { queryFlightsByAerodromeSet } from './queryFlightsByAerodromeSet.js';
+import { queryFlightsByAircraftOperator } from './queryFlightsByAircraftOperator.js';
+import { queryFlightsByAirspace } from './queryFlightsByAirspace.js';
+import { queryFlightsByMeasure } from './queryFlightsByMeasure.js';
+import { queryFlightsByTrafficVolume } from './queryFlightsByTrafficVolume.js';
+import { retrieveFlight } from './retrieveFlight.js';
 
-import type { Resolver as QueryFlightsByAirspace } from './queryFlightsByAirspace.js';
-import queryFlightsByAirspace from './queryFlightsByAirspace.js';
+const queryDefinitions = {
+  retrieveFlight,
+  queryFlightPlans,
+  queryFlightsByAerodrome,
+  queryFlightsByAerodromeSet,
+  queryFlightsByAircraftOperator,
+  queryFlightsByAirspace,
+  queryFlightsByMeasure,
+  queryFlightsByTrafficVolume,
+};
 
-import type { Resolver as QueryFlightPlans } from './queryFlightPlans.js';
-import queryFlightPlans from './queryFlightPlans.js';
-
-import type { Resolver as QueryFlightsByTrafficVolume } from './queryFlightsByTrafficVolume.js';
-import queryFlightsByTrafficVolume from './queryFlightsByTrafficVolume.js';
-
-import type { Resolver as QueryFlightsByMeasure } from './queryFlightsByMeasure.js';
-import queryFlightsByMeasure from './queryFlightsByMeasure.js';
-
-import type { Resolver as QueryFlightsByAerodrome } from './queryFlightsByAerodrome.js';
-import queryFlightsByAerodrome from './queryFlightsByAerodrome.js';
-
-import type { Resolver as QueryFlightsByAerodromeSet } from './queryFlightsByAerodromeSet.js';
-import queryFlightsByAerodromeSet from './queryFlightsByAerodromeSet.js';
-
-import type { BaseServiceInterface } from '../Common/ServiceInterface.js';
-import type { Resolver as QueryFlightsByAircraftOperator } from './queryFlightsByAircraftOperator.js';
-import queryFlightsByAircraftOperator from './queryFlightsByAircraftOperator.js';
-
-export type FlightClient = SoapClient;
-
-export interface FlightService extends BaseServiceInterface {
-  retrieveFlight: RetrieveFlight;
-  queryFlightsByAirspace: QueryFlightsByAirspace;
-  queryFlightPlans: QueryFlightPlans;
-  queryFlightsByTrafficVolume: QueryFlightsByTrafficVolume;
-  queryFlightsByMeasure: QueryFlightsByMeasure;
-  queryFlightsByAerodrome: QueryFlightsByAerodrome;
-  queryFlightsByAerodromeSet: QueryFlightsByAerodromeSet;
-  queryFlightsByAircraftOperator: QueryFlightsByAircraftOperator;
-}
+export type FlightService = SoapService<typeof queryDefinitions>;
 
 export async function getFlightClient(config: Config): Promise<FlightService> {
-  const WSDL = getWSDLPath({
-    service: 'FlightServices',
-    flavour: config.flavour,
-    XSD_PATH: config.XSD_PATH,
+  const service = await createService({
+    serviceName: 'FlightServices',
+    config,
+    queryDefinitions,
   });
 
-  const security = prepareSecurity(config);
-
-  const client = await createClientAsync(WSDL, { customDeserializer });
-  client.setSecurity(security);
-
-  return {
-    __soapClient: client,
-    config,
-    retrieveFlight: retrieveFlight(client),
-    queryFlightsByAirspace: queryFlightsByAirspace(client),
-    queryFlightPlans: queryFlightPlans(client),
-    queryFlightsByTrafficVolume: queryFlightsByTrafficVolume(client),
-    queryFlightsByMeasure: queryFlightsByMeasure(client),
-    queryFlightsByAerodrome: queryFlightsByAerodrome(client),
-    queryFlightsByAerodromeSet: queryFlightsByAerodromeSet(client),
-    queryFlightsByAircraftOperator: queryFlightsByAircraftOperator(client),
-  };
+  return service;
 }

--- a/src/Flight/queryFlightPlans.ts
+++ b/src/Flight/queryFlightPlans.ts
@@ -1,45 +1,16 @@
-import type { FlightClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import type { FlightPlanListRequest, FlightPlanListReply } from './types.js';
-export type { FlightPlanListRequest, FlightPlanListReply } from './types.js';
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
+import type { FlightPlanListReply, FlightPlanListRequest } from './types.js';
 
-type Input = InjectSendTime<FlightPlanListRequest>;
-type Result = FlightPlanListReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryFlightPlans(
-  client: FlightClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const queryFlightPlans = createSoapQueryDefinition<
+  FlightPlanListRequest,
+  FlightPlanListReply
+>({
+  service: 'Flight',
+  query: 'queryFlightPlans',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .queryFlightPlans.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'queryFlightPlans',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryFlightPlans(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryFlightPlans.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryFlightPlansAsync,
+});

--- a/src/Flight/queryFlightPlans.ts
+++ b/src/Flight/queryFlightPlans.ts
@@ -11,6 +11,4 @@ export const queryFlightPlans = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightPlans.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightPlansAsync,
 });

--- a/src/Flight/queryFlightsByAerodrome.ts
+++ b/src/Flight/queryFlightsByAerodrome.ts
@@ -14,6 +14,4 @@ export const queryFlightsByAerodrome = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightsByAerodrome.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightsByAerodromeAsync,
 });

--- a/src/Flight/queryFlightsByAerodrome.ts
+++ b/src/Flight/queryFlightsByAerodrome.ts
@@ -1,53 +1,19 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { FlightClient } from './index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   FlightListByAerodromeReply,
   FlightListByAerodromeRequest,
 } from './types.js';
 
-export type {
-  FlightListByAerodromeReply,
+export const queryFlightsByAerodrome = createSoapQueryDefinition<
   FlightListByAerodromeRequest,
-} from './types.js';
-
-type Input = InjectSendTime<FlightListByAerodromeRequest>;
-type Result = FlightListByAerodromeReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryFlightsByAerodrome(
-  client: FlightClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  FlightListByAerodromeReply
+>({
+  service: 'Flight',
+  query: 'queryFlightsByAerodrome',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .queryFlightsByAerodrome.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'queryFlightsByAerodrome',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryFlightsByAerodrome(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryFlightsByAerodrome.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryFlightsByAerodromeAsync,
+});

--- a/src/Flight/queryFlightsByAerodromeSet.ts
+++ b/src/Flight/queryFlightsByAerodromeSet.ts
@@ -1,53 +1,19 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { FlightClient } from './index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   FlightListByAerodromeSetReply,
   FlightListByAerodromeSetRequest,
 } from './types.js';
 
-export type {
-  FlightListByAerodromeSetReply,
+export const queryFlightsByAerodromeSet = createSoapQueryDefinition<
   FlightListByAerodromeSetRequest,
-} from './types.js';
-
-type Input = InjectSendTime<FlightListByAerodromeSetRequest>;
-type Result = FlightListByAerodromeSetReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryFlightsByAerodromeSet(
-  client: FlightClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  FlightListByAerodromeSetReply
+>({
+  service: 'Flight',
+  query: 'queryFlightsByAerodromeSet',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .queryFlightsByAerodromeSet.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'queryFlightsByAerodromeSet',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryFlightsByAerodromeSet(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryFlightsByAerodromeSet.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryFlightsByAerodromeSetAsync,
+});

--- a/src/Flight/queryFlightsByAerodromeSet.ts
+++ b/src/Flight/queryFlightsByAerodromeSet.ts
@@ -14,6 +14,4 @@ export const queryFlightsByAerodromeSet = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightsByAerodromeSet.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightsByAerodromeSetAsync,
 });

--- a/src/Flight/queryFlightsByAircraftOperator.ts
+++ b/src/Flight/queryFlightsByAircraftOperator.ts
@@ -1,53 +1,19 @@
-import type { FlightClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
-  FlightListByAircraftOperatorRequest,
   FlightListByAircraftOperatorReply,
+  FlightListByAircraftOperatorRequest,
 } from './types.js';
 
-export type {
+export const queryFlightsByAircraftOperator = createSoapQueryDefinition<
   FlightListByAircraftOperatorRequest,
-  FlightListByAircraftOperatorReply,
-} from './types.js';
-
-type Input = InjectSendTime<FlightListByAircraftOperatorRequest>;
-type Result = FlightListByAircraftOperatorReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryFlightsByAircraftOperator(
-  client: FlightClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  FlightListByAircraftOperatorReply
+>({
+  service: 'Flight',
+  query: 'queryFlightsByAircraftOperator',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .queryFlightsByAircraftOperator.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'queryFlightsByAircraftOperator',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryFlightsByAircraftOperator(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryFlightsByAircraftOperator.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryFlightsByAircraftOperatorAsync,
+});

--- a/src/Flight/queryFlightsByAircraftOperator.ts
+++ b/src/Flight/queryFlightsByAircraftOperator.ts
@@ -14,6 +14,4 @@ export const queryFlightsByAircraftOperator = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightsByAircraftOperator.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightsByAircraftOperatorAsync,
 });

--- a/src/Flight/queryFlightsByAirspace.ts
+++ b/src/Flight/queryFlightsByAirspace.ts
@@ -14,6 +14,4 @@ export const queryFlightsByAirspace = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightsByAirspace.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightsByAirspaceAsync,
 });

--- a/src/Flight/queryFlightsByMeasure.ts
+++ b/src/Flight/queryFlightsByMeasure.ts
@@ -14,6 +14,4 @@ export const queryFlightsByMeasure = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightsByMeasure.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightsByMeasureAsync,
 });

--- a/src/Flight/queryFlightsByMeasure.ts
+++ b/src/Flight/queryFlightsByMeasure.ts
@@ -1,53 +1,19 @@
-import type { FlightClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   FlightListByMeasureRequest,
   FlightListByMeasureReply,
 } from './types.js';
 
-export type {
+export const queryFlightsByMeasure = createSoapQueryDefinition<
   FlightListByMeasureRequest,
-  FlightListByMeasureReply,
-} from './types.js';
-
-type Input = InjectSendTime<FlightListByMeasureRequest>;
-type Result = FlightListByMeasureReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryFlightsByMeasure(
-  client: FlightClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  FlightListByMeasureReply
+>({
+  service: 'Flight',
+  query: 'queryFlightsByMeasure',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .queryFlightsByMeasure.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'queryFlightsByMeasure',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryFlightsByMeasure(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryFlightsByMeasure.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryFlightsByMeasureAsync,
+});

--- a/src/Flight/queryFlightsByTrafficVolume.ts
+++ b/src/Flight/queryFlightsByTrafficVolume.ts
@@ -1,53 +1,19 @@
-import type { FlightClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   FlightListByTrafficVolumeRequest,
   FlightListByTrafficVolumeReply,
 } from './types.js';
 
-export type {
+export const queryFlightsByTrafficVolume = createSoapQueryDefinition<
   FlightListByTrafficVolumeRequest,
-  FlightListByTrafficVolumeReply,
-} from './types.js';
-
-type Input = InjectSendTime<FlightListByTrafficVolumeRequest>;
-type Result = FlightListByTrafficVolumeReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryFlightsByTrafficVolume(
-  client: FlightClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  FlightListByTrafficVolumeReply
+>({
+  service: 'Flight',
+  query: 'queryFlightsByTrafficVolume',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .queryFlightsByTrafficVolume.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'queryFlightsByTrafficVolume',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryFlightsByTrafficVolume(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryFlightsByTrafficVolume.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryFlightsByTrafficVolumeAsync,
+});

--- a/src/Flight/queryFlightsByTrafficVolume.ts
+++ b/src/Flight/queryFlightsByTrafficVolume.ts
@@ -14,6 +14,4 @@ export const queryFlightsByTrafficVolume = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .queryFlightsByTrafficVolume.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryFlightsByTrafficVolumeAsync,
 });

--- a/src/Flight/retrieveFlight.ts
+++ b/src/Flight/retrieveFlight.ts
@@ -1,44 +1,16 @@
-import type { FlightClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
+import type { FlightRetrievalReply, FlightRetrievalRequest } from './types.js';
 
-import type { FlightRetrievalRequest, FlightRetrievalReply } from './types.js';
-export type { FlightRetrievalRequest, FlightRetrievalReply } from './types.js';
-
-type Input = InjectSendTime<FlightRetrievalRequest>;
-type Result = FlightRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveFlight(client: FlightClient): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const retrieveFlight = createSoapQueryDefinition<
+  FlightRetrievalRequest,
+  FlightRetrievalReply
+>({
+  service: 'Flight',
+  query: 'retrieveFlight',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
-      .retrieveFlight.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flight',
-    query: 'retrieveFlight',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveFlight(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveFlight.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.retrieveFlightAsync,
+});

--- a/src/Flight/retrieveFlight.ts
+++ b/src/Flight/retrieveFlight.ts
@@ -11,6 +11,4 @@ export const retrieveFlight = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().FlightManagementService.FlightManagementPort
       .retrieveFlight.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.retrieveFlightAsync,
 });

--- a/src/Flow/index.ts
+++ b/src/Flow/index.ts
@@ -1,71 +1,41 @@
-import { createClientAsync, type Client as SoapClient } from 'soap';
 import type { Config } from '../config.js';
-import { getWSDLPath } from '../constants.js';
-import { prepareSecurity } from '../security.js';
-import { deserializer as customDeserializer } from '../utils/transformers/index.js';
+import {
+  createService,
+  type SoapService,
+} from '../utils/soap-query-definition.js';
 
-import type { BaseServiceInterface } from '../Common/ServiceInterface.js';
-import type { Resolver as QueryHotspots } from './queryHotspots.js';
-import queryHotspots from './queryHotspots.js';
-import type { Resolver as QueryRegulations } from './queryRegulations.js';
-import queryRegulations from './queryRegulations.js';
-import type { Resolver as QueryTrafficCountsByAirspace } from './queryTrafficCountsByAirspace.js';
-import queryTrafficCountsByAirspace from './queryTrafficCountsByAirspace.js';
-import type { Resolver as QueryTrafficCountsByTrafficVolume } from './queryTrafficCountsByTrafficVolume.js';
-import queryTrafficCountsByTrafficVolume from './queryTrafficCountsByTrafficVolume.js';
-import type { Resolver as RetrieveCapacityPlan } from './retrieveCapacityPlan.js';
-import retrieveCapacityPlan from './retrieveCapacityPlan.js';
-import type { Resolver as RetrieveOTMVPlan } from './retrieveOTMVPlan.js';
-import retrieveOTMVPlan from './retrieveOTMVPlan.js';
-import type { Resolver as RetrieveRunwayConfigurationPlan } from './retrieveRunwayConfigurationPlan.js';
-import retrieveRunwayConfigurationPlan from './retrieveRunwayConfigurationPlan.js';
-import type { Resolver as RetrieveSectorConfigurationPlan } from './retrieveSectorConfigurationPlan.js';
-import retrieveSectorConfigurationPlan from './retrieveSectorConfigurationPlan.js';
-import type { Resolver as UpdateCapacityPlan } from './updateCapacityPlan.js';
-import updateCapacityPlan from './updateCapacityPlan.js';
-import type { Resolver as UpdateOTMVPlan } from './updateOTMVPlan.js';
-import updateOTMVPlan from './updateOTMVPlan.js';
+import { queryHotspots } from './queryHotspots.js';
+import { queryRegulations } from './queryRegulations.js';
+import { queryTrafficCountsByAirspace } from './queryTrafficCountsByAirspace.js';
+import { queryTrafficCountsByTrafficVolume } from './queryTrafficCountsByTrafficVolume.js';
+import { retrieveCapacityPlan } from './retrieveCapacityPlan.js';
+import { retrieveOTMVPlan } from './retrieveOTMVPlan.js';
+import { retrieveRunwayConfigurationPlan } from './retrieveRunwayConfigurationPlan.js';
+import { retrieveSectorConfigurationPlan } from './retrieveSectorConfigurationPlan.js';
+import { updateCapacityPlan } from './updateCapacityPlan.js';
+import { updateOTMVPlan } from './updateOTMVPlan.js';
 
-export type FlowClient = SoapClient;
+const queryDefinitions = {
+  queryHotspots,
+  queryRegulations,
+  queryTrafficCountsByAirspace,
+  queryTrafficCountsByTrafficVolume,
+  retrieveCapacityPlan,
+  retrieveOTMVPlan,
+  retrieveRunwayConfigurationPlan,
+  retrieveSectorConfigurationPlan,
+  updateCapacityPlan,
+  updateOTMVPlan,
+};
 
-export interface FlowService extends BaseServiceInterface {
-  retrieveSectorConfigurationPlan: RetrieveSectorConfigurationPlan;
-  queryTrafficCountsByAirspace: QueryTrafficCountsByAirspace;
-  queryRegulations: QueryRegulations;
-  queryHotspots: QueryHotspots;
-  queryTrafficCountsByTrafficVolume: QueryTrafficCountsByTrafficVolume;
-  retrieveOTMVPlan: RetrieveOTMVPlan;
-  updateOTMVPlan: UpdateOTMVPlan;
-  retrieveCapacityPlan: RetrieveCapacityPlan;
-  updateCapacityPlan: UpdateCapacityPlan;
-  retrieveRunwayConfigurationPlan: RetrieveRunwayConfigurationPlan;
-}
+export type FlowService = SoapService<typeof queryDefinitions>;
 
 export async function getFlowClient(config: Config): Promise<FlowService> {
-  const WSDL = getWSDLPath({
-    service: 'FlowServices',
-    flavour: config.flavour,
-    XSD_PATH: config.XSD_PATH,
+  const service = await createService({
+    serviceName: 'FlowServices',
+    config,
+    queryDefinitions,
   });
 
-  const security = prepareSecurity(config);
-
-  const client = await createClientAsync(WSDL, { customDeserializer });
-  client.setSecurity(security);
-
-  return {
-    __soapClient: client,
-    config,
-    retrieveSectorConfigurationPlan: retrieveSectorConfigurationPlan(client),
-    queryTrafficCountsByAirspace: queryTrafficCountsByAirspace(client),
-    queryRegulations: queryRegulations(client),
-    queryHotspots: queryHotspots(client),
-    queryTrafficCountsByTrafficVolume:
-      queryTrafficCountsByTrafficVolume(client),
-    retrieveOTMVPlan: retrieveOTMVPlan(client),
-    updateOTMVPlan: updateOTMVPlan(client),
-    retrieveCapacityPlan: retrieveCapacityPlan(client),
-    updateCapacityPlan: updateCapacityPlan(client),
-    retrieveRunwayConfigurationPlan: retrieveRunwayConfigurationPlan(client),
-  };
+  return service;
 }

--- a/src/Flow/index.ts
+++ b/src/Flow/index.ts
@@ -1,6 +1,6 @@
 import type { Config } from '../config.js';
 import {
-  createService,
+  createSoapService,
   type SoapService,
 } from '../utils/soap-query-definition.js';
 
@@ -31,7 +31,7 @@ const queryDefinitions = {
 export type FlowService = SoapService<typeof queryDefinitions>;
 
 export async function getFlowClient(config: Config): Promise<FlowService> {
-  const service = await createService({
+  const service = await createSoapService({
     serviceName: 'FlowServices',
     config,
     queryDefinitions,

--- a/src/Flow/queryHotspots.ts
+++ b/src/Flow/queryHotspots.ts
@@ -1,44 +1,14 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type { HotspotListRequest, HotspotListReply } from './types.js';
-export type { HotspotListRequest, HotspotListReply } from './types.js';
 
-type Input = InjectSendTime<HotspotListRequest>;
-type Result = HotspotListReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryHotspots(client: FlowClient): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const queryHotspots = createSoapQueryDefinition<
+  HotspotListRequest,
+  HotspotListReply
+>({
+  service: 'Flow',
+  query: 'queryHotspots',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort.queryHotspots
-      .input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'queryHotspots',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryHotspots(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .input,
+});

--- a/src/Flow/queryRegulations.test.ts
+++ b/src/Flow/queryRegulations.test.ts
@@ -5,7 +5,6 @@ import b2bOptions from '../../tests/options.js';
 import { shouldUseRealB2BConnection } from '../../tests/utils.js';
 import { NMB2BError, createFlowClient } from '../index.js';
 import { extractReferenceLocation } from '../utils/extractReferenceLocation.js';
-import type { RegulationListReply } from './queryRegulations.js';
 
 describe('queryRegulations', async () => {
   const Flow = await createFlowClient(b2bOptions);
@@ -46,7 +45,7 @@ describe('queryRegulations', async () => {
 
   test.runIf(shouldUseRealB2BConnection)('List all regulations', async () => {
     try {
-      const res: RegulationListReply = await Flow.queryRegulations({
+      const res = await Flow.queryRegulations({
         dataset: { type: 'OPERATIONAL' },
         queryPeriod: {
           wef: startOfHour(sub(new Date(), { hours: 10 })),

--- a/src/Flow/queryRegulations.ts
+++ b/src/Flow/queryRegulations.ts
@@ -1,43 +1,13 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type { RegulationListRequest, RegulationListReply } from './types.js';
-export type { RegulationListRequest, RegulationListReply } from './types.js';
 
-type Input = InjectSendTime<RegulationListRequest>;
-type Result = RegulationListReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryRegulations(client: FlowClient): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    client.describe().MeasuresService.MeasuresPort.queryRegulations.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'queryRegulations',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryRegulations(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+export const queryRegulations = createSoapQueryDefinition<
+  RegulationListRequest,
+  RegulationListReply
+>({
+  service: 'Flow',
+  query: 'queryRegulations',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    client.describe().MeasuresService.MeasuresPort.queryRegulations.input,
+});

--- a/src/Flow/queryTrafficCountsByAirspace.ts
+++ b/src/Flow/queryTrafficCountsByAirspace.ts
@@ -1,53 +1,17 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   TrafficCountsByAirspaceRequest,
   TrafficCountsByAirspaceReply,
 } from './types.js';
 
-export type {
+export const queryTrafficCountsByAirspace = createSoapQueryDefinition<
   TrafficCountsByAirspaceRequest,
-  TrafficCountsByAirspaceReply,
-} from './types.js';
-
-type Input = InjectSendTime<TrafficCountsByAirspaceRequest>;
-type Result = TrafficCountsByAirspaceReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryTrafficCountsByAirspace(
-  client: FlowClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  TrafficCountsByAirspaceReply
+>({
+  service: 'Flow',
+  query: 'queryTrafficCountsByAirspace',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TrafficCountsService.TrafficCountsPort
-      .queryTrafficCountsByAirspace.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'queryTrafficCountsByAirspace',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryTrafficCountsByAirspace(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryTrafficCountsByAirspace.input,
+});

--- a/src/Flow/queryTrafficCountsByTrafficVolume.ts
+++ b/src/Flow/queryTrafficCountsByTrafficVolume.ts
@@ -1,53 +1,17 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   TrafficCountsByTrafficVolumeRequest,
   TrafficCountsByTrafficVolumeReply,
 } from './types.js';
 
-export type {
+export const queryTrafficCountsByTrafficVolume = createSoapQueryDefinition<
   TrafficCountsByTrafficVolumeRequest,
-  TrafficCountsByTrafficVolumeReply,
-} from './types.js';
-
-type Input = InjectSendTime<TrafficCountsByTrafficVolumeRequest>;
-type Result = TrafficCountsByTrafficVolumeReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryTrafficCountsByTrafficVolume(
-  client: FlowClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  TrafficCountsByTrafficVolumeReply
+>({
+  service: 'Flow',
+  query: 'queryTrafficCountsByTrafficVolume',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TrafficCountsService.TrafficCountsPort
-      .queryTrafficCountsByTrafficVolume.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'queryTrafficCountsByTrafficVolume',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.queryTrafficCountsByTrafficVolume(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .queryTrafficCountsByTrafficVolume.input,
+});

--- a/src/Flow/retrieveCapacityPlan.ts
+++ b/src/Flow/retrieveCapacityPlan.ts
@@ -1,53 +1,17 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   CapacityPlanRetrievalRequest,
   CapacityPlanRetrievalReply,
 } from './types.js';
 
-export type {
+export const retrieveCapacityPlan = createSoapQueryDefinition<
   CapacityPlanRetrievalRequest,
-  CapacityPlanRetrievalReply,
-} from './types.js';
-
-type Input = InjectSendTime<CapacityPlanRetrievalRequest>;
-type Result = CapacityPlanRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveCapacityPlan(
-  client: FlowClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  CapacityPlanRetrievalReply
+>({
+  service: 'Flow',
+  query: 'retrieveCapacityPlan',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort
-      .retrieveCapacityPlan.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'retrieveCapacityPlan',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveCapacityPlan(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveCapacityPlan.input,
+});

--- a/src/Flow/retrieveOTMVPlan.ts
+++ b/src/Flow/retrieveOTMVPlan.ts
@@ -1,51 +1,17 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
   OTMVPlanRetrievalRequest,
   OTMVPlanRetrievalReply,
 } from './types.js';
-export type {
+
+export const retrieveOTMVPlan = createSoapQueryDefinition<
   OTMVPlanRetrievalRequest,
-  OTMVPlanRetrievalReply,
-} from './types.js';
-
-type Input = InjectSendTime<OTMVPlanRetrievalRequest>;
-type Result = OTMVPlanRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveOTMVPlan(client: FlowClient): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  OTMVPlanRetrievalReply
+>({
+  service: 'Flow',
+  query: 'retrieveOTMVPlan',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort
-      .retrieveOTMVPlan.input;
-
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'retrieveOTMVPlan',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveOTMVPlan(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveOTMVPlan.input,
+});

--- a/src/Flow/retrieveRunwayConfigurationPlan.ts
+++ b/src/Flow/retrieveRunwayConfigurationPlan.ts
@@ -1,53 +1,17 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
-  RunwayConfigurationPlanRetrievalRequest,
   RunwayConfigurationPlanRetrievalReply,
+  RunwayConfigurationPlanRetrievalRequest,
 } from './types.js';
 
-export type {
+export const retrieveRunwayConfigurationPlan = createSoapQueryDefinition<
   RunwayConfigurationPlanRetrievalRequest,
-  RunwayConfigurationPlanRetrievalReply,
-} from './types.js';
-
-type Input = InjectSendTime<RunwayConfigurationPlanRetrievalRequest>;
-type Result = RunwayConfigurationPlanRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveRunwayConfigurationPlan(
-  client: FlowClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  RunwayConfigurationPlanRetrievalReply
+>({
+  service: 'Flow',
+  query: 'retrieveRunwayConfigurationPlan',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort
-      .retrieveRunwayConfigurationPlan.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'retrieveRunwayConfigurationPlan',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveRunwayConfigurationPlan(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveRunwayConfigurationPlan.input,
+});

--- a/src/Flow/retrieveSectorConfigurationPlan.ts
+++ b/src/Flow/retrieveSectorConfigurationPlan.ts
@@ -1,61 +1,24 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
-import type {
-  SectorConfigurationPlanRetrievalRequest,
-  SectorConfigurationPlanRetrievalReply,
-  KnownConfigurations,
-  SectorConfigurationId,
-} from './types.js';
-
 import type { AirspaceId } from '../Airspace/types.js';
 import type { SafeB2BDeserializedResponse } from '../types.js';
-
-export type {
-  SectorConfigurationPlanRetrievalRequest,
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
+import type {
+  KnownConfigurations,
+  SectorConfigurationId,
   SectorConfigurationPlanRetrievalReply,
+  SectorConfigurationPlanRetrievalRequest,
 } from './types.js';
 
-type Input = InjectSendTime<SectorConfigurationPlanRetrievalRequest>;
-type Result = SectorConfigurationPlanRetrievalReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveSectorConfigurationPlan(
-  client: FlowClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const retrieveSectorConfigurationPlan = createSoapQueryDefinition<
+  SectorConfigurationPlanRetrievalRequest,
+  SectorConfigurationPlanRetrievalReply
+>({
+  service: 'Flow',
+  query: 'retrieveSectorConfigurationPlan',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort
-      .retrieveSectorConfigurationPlan.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'retrieveSectorConfigurationPlan',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.retrieveSectorConfigurationPlan(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .retrieveSectorConfigurationPlan.input,
+});
 
 export function knownConfigurationsToMap(
   knownConfigurations:

--- a/src/Flow/updateCapacityPlan.ts
+++ b/src/Flow/updateCapacityPlan.ts
@@ -1,54 +1,17 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type {
-  CapacityPlanUpdateRequest,
   CapacityPlanUpdateReply,
+  CapacityPlanUpdateRequest,
 } from './types.js';
 
-export type {
+export const updateCapacityPlan = createSoapQueryDefinition<
   CapacityPlanUpdateRequest,
-  CapacityPlanUpdateReply,
-} from './types.js';
-
-type Input = InjectSendTime<CapacityPlanUpdateRequest>;
-type Result = CapacityPlanUpdateReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareUpdateCapacityPlan(
-  client: FlowClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  CapacityPlanUpdateReply
+>({
+  service: 'Flow',
+  query: 'updateCapacityPlan',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort
-      .updateCapacityPlan.input;
-
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'updateCapacityPlan',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.updateCapacityPlan(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .updateCapacityPlan.input,
+});

--- a/src/Flow/updateOTMVPlan.ts
+++ b/src/Flow/updateOTMVPlan.ts
@@ -1,45 +1,14 @@
-import type { FlowClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
+import type { OTMVPlanUpdateReply, OTMVPlanUpdateRequest } from './types.js';
 
-import type { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types.js';
-
-export type { OTMVPlanUpdateRequest, OTMVPlanUpdateReply } from './types.js';
-
-type Input = InjectSendTime<OTMVPlanUpdateRequest>;
-type Result = OTMVPlanUpdateReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareUpdateOTMVPlan(client: FlowClient): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const updateOTMVPlan = createSoapQueryDefinition<
+  OTMVPlanUpdateRequest,
+  OTMVPlanUpdateReply
+>({
+  service: 'Flow',
+  query: 'updateOTMVPlan',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().TacticalUpdatesService.TacticalUpdatesPort.updateOTMVPlan
-      .input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'Flow',
-    query: 'updateOTMVPlan',
-  })(
-    (values, options) =>
-      new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        client.updateOTMVPlan(
-          serializer(injectSendTime(values)),
-          options,
-          responseStatusHandler(resolve, reject),
-        );
-      }),
-  );
-}
+      .input,
+});

--- a/src/GeneralInformation/index.ts
+++ b/src/GeneralInformation/index.ts
@@ -1,6 +1,6 @@
 import type { Config } from '../config.js';
 import {
-  createService,
+  createSoapService,
   type SoapService,
 } from '../utils/soap-query-definition.js';
 import { queryNMB2BWSDLsDefinition } from './queryNMB2BWSDLs.js';
@@ -17,7 +17,7 @@ export type GeneralInformationService = SoapService<typeof queryDefinitions>;
 export async function getGeneralInformationClient(
   config: Config,
 ): Promise<GeneralInformationService> {
-  const service = await createService({
+  const service = await createSoapService({
     serviceName: 'GeneralinformationServices',
     config,
     queryDefinitions,

--- a/src/GeneralInformation/index.ts
+++ b/src/GeneralInformation/index.ts
@@ -1,43 +1,27 @@
-import { createClientAsync, type Client as SoapClient } from 'soap';
 import type { Config } from '../config.js';
-import { getWSDLPath } from '../constants.js';
-import { prepareSecurity } from '../security.js';
-import { deserializer as customDeserializer } from '../utils/transformers/index.js';
+import {
+  createService,
+  type SoapService,
+} from '../utils/soap-query-definition.js';
+import { queryNMB2BWSDLsDefinition } from './queryNMB2BWSDLs.js';
 
-import type { Resolver as QueryNMB2BWSDLs } from './queryNMB2BWSDLs.js';
-import queryNMB2BWSDLs from './queryNMB2BWSDLs.js';
+import { retrieveUserInformation } from './retrieveUserinformation.js';
 
-import type { Resolver as RetrieveUserInformation } from './retrieveUserinformation.js';
-import retrieveUserInformation from './retrieveUserinformation.js';
+const queryDefinitions = {
+  queryNMB2BWSDLs: queryNMB2BWSDLsDefinition,
+  retrieveUserInformation,
+};
 
-import type { BaseServiceInterface } from '../Common/ServiceInterface.js';
-
-export type GeneralInformationServiceClient = SoapClient;
-
-export interface GeneralInformationService extends BaseServiceInterface {
-  __soapClient: object;
-  queryNMB2BWSDLs: QueryNMB2BWSDLs;
-  retrieveUserInformation: RetrieveUserInformation;
-}
+export type GeneralInformationService = SoapService<typeof queryDefinitions>;
 
 export async function getGeneralInformationClient(
   config: Config,
 ): Promise<GeneralInformationService> {
-  const WSDL = getWSDLPath({
-    service: 'GeneralinformationServices',
-    flavour: config.flavour,
-    XSD_PATH: config.XSD_PATH,
+  const service = await createService({
+    serviceName: 'GeneralinformationServices',
+    config,
+    queryDefinitions,
   });
 
-  const security = prepareSecurity(config);
-
-  const client = await createClientAsync(WSDL, { customDeserializer });
-  client.setSecurity(security);
-
-  return {
-    __soapClient: client,
-    config,
-    queryNMB2BWSDLs: queryNMB2BWSDLs(client),
-    retrieveUserInformation: retrieveUserInformation(client),
-  };
+  return service;
 }

--- a/src/GeneralInformation/index.ts
+++ b/src/GeneralInformation/index.ts
@@ -3,12 +3,12 @@ import {
   createSoapService,
   type SoapService,
 } from '../utils/soap-query-definition.js';
-import { queryNMB2BWSDLsDefinition } from './queryNMB2BWSDLs.js';
 
+import { queryNMB2BWSDLs } from './queryNMB2BWSDLs.js';
 import { retrieveUserInformation } from './retrieveUserinformation.js';
 
 const queryDefinitions = {
-  queryNMB2BWSDLs: queryNMB2BWSDLsDefinition,
+  queryNMB2BWSDLs,
   retrieveUserInformation,
 };
 

--- a/src/GeneralInformation/queryNMB2BWSDLs.ts
+++ b/src/GeneralInformation/queryNMB2BWSDLs.ts
@@ -10,6 +10,4 @@ export const queryNMB2BWSDLsDefinition = createSoapQueryDefinition<
   getSchema: (client) =>
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().NMB2BInfoService.NMB2BInfoPort.queryNMB2BWSDLs.input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.queryNMB2BWSDLsAsync,
 });

--- a/src/GeneralInformation/queryNMB2BWSDLs.ts
+++ b/src/GeneralInformation/queryNMB2BWSDLs.ts
@@ -1,7 +1,7 @@
 import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type { NMB2BWSDLsReply, NMB2BWSDLsRequest } from './types.js';
 
-export const queryNMB2BWSDLsDefinition = createSoapQueryDefinition<
+export const queryNMB2BWSDLs = createSoapQueryDefinition<
   NMB2BWSDLsRequest,
   NMB2BWSDLsReply
 >({

--- a/src/GeneralInformation/queryNMB2BWSDLs.ts
+++ b/src/GeneralInformation/queryNMB2BWSDLs.ts
@@ -1,44 +1,15 @@
-import type { GeneralInformationServiceClient } from './index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import type { SoapOptions } from '../soap.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import { instrument } from '../utils/instrumentation/index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type { NMB2BWSDLsReply, NMB2BWSDLsRequest } from './types.js';
-export type { NMB2BWSDLsReply, NMB2BWSDLsRequest };
 
-type Input = InjectSendTime<NMB2BWSDLsRequest>;
-type Result = NMB2BWSDLsReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareQueryNMB2BWSDLs(
-  client: GeneralInformationServiceClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    client.describe().NMB2BInfoService.NMB2BInfoPort.queryNMB2BWSDLs.input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'GeneralInformation',
-    query: 'queryNMB2BWSDLs',
-  })((values, options) => {
-    return new Promise((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      client.queryNMB2BWSDLs(
-        serializer(injectSendTime(values)),
-        options,
-        responseStatusHandler(resolve, reject),
-      );
-    });
-  });
-}
+export const queryNMB2BWSDLsDefinition = createSoapQueryDefinition<
+  NMB2BWSDLsRequest,
+  NMB2BWSDLsReply
+>({
+  service: 'GeneralInformation',
+  query: 'queryNMB2BWSDLs',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    client.describe().NMB2BInfoService.NMB2BInfoPort.queryNMB2BWSDLs.input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.queryNMB2BWSDLsAsync,
+});

--- a/src/GeneralInformation/retrieveUserinformation.ts
+++ b/src/GeneralInformation/retrieveUserinformation.ts
@@ -11,6 +11,4 @@ export const retrieveUserInformation = createSoapQueryDefinition<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().NMB2BInfoService.NMB2BInfoPort.retrieveUserInformation
       .input,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  executeQuery: (client) => client.retrieveUserInformationAsync,
 });

--- a/src/GeneralInformation/retrieveUserinformation.ts
+++ b/src/GeneralInformation/retrieveUserinformation.ts
@@ -1,45 +1,16 @@
-import type { SoapOptions } from '../soap.js';
-import { instrument } from '../utils/instrumentation/index.js';
-import {
-  injectSendTime,
-  responseStatusHandler,
-  type InjectSendTime,
-} from '../utils/internals.js';
-import { prepareSerializer } from '../utils/transformers/index.js';
-import type { GeneralInformationServiceClient } from './index.js';
-
+import { createSoapQueryDefinition } from '../utils/soap-query-definition.js';
 import type { UserInformationReply, UserInformationRequest } from './types.js';
-export type { UserInformationReply, UserInformationRequest };
 
-type Input = InjectSendTime<UserInformationRequest>;
-type Result = UserInformationReply;
-
-export type Resolver = (
-  values: Input,
-  options?: SoapOptions,
-) => Promise<Result>;
-
-export default function prepareRetrieveUserInformation(
-  client: GeneralInformationServiceClient,
-): Resolver {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const schema =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+export const retrieveUserInformation = createSoapQueryDefinition<
+  UserInformationRequest,
+  UserInformationReply
+>({
+  service: 'GeneralInformation',
+  query: 'retrieveUserInformation',
+  getSchema: (client) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     client.describe().NMB2BInfoService.NMB2BInfoPort.retrieveUserInformation
-      .input;
-  const serializer = prepareSerializer(schema);
-
-  return instrument<Input, Result>({
-    service: 'GeneralInformation',
-    query: 'retrieveUserInformation',
-  })((values, options) => {
-    return new Promise((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      client.retrieveUserInformation(
-        serializer(injectSendTime(values)),
-        options,
-        responseStatusHandler(resolve, reject),
-      );
-    });
-  });
-}
+      .input,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  executeQuery: (client) => client.retrieveUserInformationAsync,
+});

--- a/src/utils/instrumentation/index.ts
+++ b/src/utils/instrumentation/index.ts
@@ -1,4 +1,3 @@
-// import withLog from './withLog';
 import type { SoapOptions } from '../../soap.js';
 import { withLog } from './withLog.js';
 import { pipe } from 'remeda';

--- a/src/utils/internals.ts
+++ b/src/utils/internals.ts
@@ -13,28 +13,6 @@ export function injectSendTime<T extends B2BRequest>(
   return { sendTime, ...values } as T;
 }
 
-type Cb = (...args: any[]) => void;
-
-export function responseStatusHandler(resolve: Cb, reject: Cb) {
-  return (err: unknown, reply: Reply) => {
-    if (err) {
-      reject(err);
-      return;
-    }
-
-    if (reply.status === 'OK') {
-      resolve(reply);
-      return;
-    } else {
-      const err = new NMB2BError({
-        reply: reply as Reply & { status: Exclude<ReplyStatus, 'OK'> },
-      });
-      reject(err);
-      return;
-    }
-  };
-}
-
 export function assertOkReply<T extends Reply>(
   reply: T,
 ): asserts reply is T & { status: 'OK' } {

--- a/src/utils/internals.ts
+++ b/src/utils/internals.ts
@@ -1,12 +1,12 @@
 import type { B2BRequest, Reply, ReplyStatus } from '../Common/types.js';
 import { NMB2BError } from './NMB2BError.js';
 
-export type InjectSendTime<T extends B2BRequest> = Omit<T, 'sendTime'> & {
+export type WithInjectedSendTime<T extends B2BRequest> = Omit<T, 'sendTime'> & {
   sendTime?: Date | undefined;
 };
 
 export function injectSendTime<T extends B2BRequest>(
-  values: InjectSendTime<T>,
+  values: WithInjectedSendTime<T>,
 ): T {
   const sendTime = new Date();
 

--- a/src/utils/internals.ts
+++ b/src/utils/internals.ts
@@ -1,15 +1,16 @@
-import type { SetOptional } from 'type-fest';
 import type { B2BRequest, Reply, ReplyStatus } from '../Common/types.js';
 import { NMB2BError } from './NMB2BError.js';
 
-export type InjectSendTime<T extends B2BRequest> = SetOptional<T, 'sendTime'>;
+export type InjectSendTime<T extends B2BRequest> = Omit<T, 'sendTime'> & {
+  sendTime?: Date | undefined;
+};
 
-export function injectSendTime<T extends InjectSendTime<B2BRequest>>(
-  values: T,
-): T & { sendTime: Date } {
+export function injectSendTime<T extends B2BRequest>(
+  values: InjectSendTime<T>,
+): T {
   const sendTime = new Date();
 
-  return { sendTime, ...values };
+  return { sendTime, ...values } as T;
 }
 
 type Cb = (...args: any[]) => void;
@@ -32,4 +33,14 @@ export function responseStatusHandler(resolve: Cb, reject: Cb) {
       return;
     }
   };
+}
+
+export function assertOkReply<T extends Reply>(
+  reply: T,
+): asserts reply is T & { status: 'OK' } {
+  if (reply.status !== 'OK') {
+    throw new NMB2BError({
+      reply: reply as T & { status: Exclude<ReplyStatus, 'OK'> },
+    });
+  }
 }

--- a/src/utils/soap-query-definition.ts
+++ b/src/utils/soap-query-definition.ts
@@ -111,7 +111,9 @@ export type SoapService<TDefinitions extends ServiceDefinition> = {
   [TKey in keyof TDefinitions]: ExtractSoapQuery<TDefinitions[TKey]>;
 };
 
-export async function createService<TDefinitions extends ServiceDefinition>({
+export async function createSoapService<
+  TDefinitions extends ServiceDefinition,
+>({
   serviceName,
   config,
   queryDefinitions,

--- a/src/utils/soap-query-definition.ts
+++ b/src/utils/soap-query-definition.ts
@@ -119,8 +119,8 @@ function buildQueryFunctionFromSoapDefinition<
 
   const serializer = prepareSerializer<TInput>(schema);
 
-  const queryFn = queryDefinition.executeQuery
-    ? queryDefinition.executeQuery(client).bind(client)
+  let queryFn = queryDefinition.executeQuery
+    ? queryDefinition.executeQuery(client)
     : (client[`${queryDefinition.query}Async`] as
         | undefined
         | ((values: TInput, options?: SoapOptions) => Promise<[TResult]>));
@@ -129,6 +129,8 @@ function buildQueryFunctionFromSoapDefinition<
     typeof queryFn === 'function',
     `Could not find query function for query ${queryDefinition.service}.${queryDefinition.query}`,
   );
+
+  queryFn = queryFn.bind(client);
 
   return instrument<WithInjectedSendTime<TInput>, TResult>({
     service: queryDefinition.service,

--- a/src/utils/soap-query-definition.ts
+++ b/src/utils/soap-query-definition.ts
@@ -1,0 +1,106 @@
+import { createClientAsync, type Client as SoapClient } from 'soap';
+import type { B2BRequest, Reply } from '../Common/types.js';
+import type { SoapOptions } from '../soap.js';
+import { instrument } from './instrumentation/index.js';
+import {
+  assertOkReply,
+  injectSendTime,
+  type InjectSendTime,
+} from './internals.js';
+import { prepareSerializer } from './transformers/serializer.js';
+import type { Config } from '../config.js';
+import { getWSDLPath } from '../constants.js';
+import { prepareSecurity } from '../security.js';
+import { deserializer as customDeserializer } from '../utils/transformers/index.js';
+
+export type SoapQueryDefinition<TInput extends B2BRequest, TResult> = {
+  service: string;
+  query: string;
+  getSchema: (client: SoapClient) => unknown;
+  executeQuery: (
+    client: SoapClient,
+  ) => (values: TInput, options?: SoapOptions) => Promise<[TResult]>;
+};
+
+export function createSoapQueryDefinition<
+  TInput extends B2BRequest,
+  TResult extends Reply,
+>(queryDefinition: SoapQueryDefinition<TInput, TResult>) {
+  return queryDefinition;
+}
+
+export function fromSoapDefinition<
+  TInput extends B2BRequest,
+  TResult extends Reply,
+>({
+  queryDefinition,
+  client,
+}: {
+  queryDefinition: SoapQueryDefinition<TInput, TResult>;
+  client: SoapClient;
+}): (input: InjectSendTime<TInput>, options?: SoapOptions) => Promise<TResult> {
+  const schema = queryDefinition.getSchema(client);
+
+  const serializer = prepareSerializer<TInput>(schema);
+  const queryFn = queryDefinition.executeQuery(client).bind(client);
+
+  return instrument<InjectSendTime<TInput>, TResult>({
+    service: queryDefinition.service,
+    query: queryDefinition.query,
+  })(async (input, options?): Promise<TResult> => {
+    const withSendTime: TInput = injectSendTime(input);
+
+    const [result] = await queryFn(serializer(withSendTime), options);
+
+    assertOkReply(result);
+    return result;
+  });
+}
+
+export type ServiceDefinition = Record<string, SoapQueryDefinition<any, any>>;
+
+type ExtractSoapQuery<T extends SoapQueryDefinition<B2BRequest, Reply>> =
+  T extends SoapQueryDefinition<infer TInput, infer TResult>
+    ? (input: InjectSendTime<TInput>) => Promise<TResult>
+    : never;
+
+export type SoapService<TDefinitions extends ServiceDefinition> = {
+  __soapClient: SoapClient;
+  config: Config;
+} & {
+  [TKey in keyof TDefinitions]: ExtractSoapQuery<TDefinitions[TKey]>;
+};
+
+export async function createService<TDefinitions extends ServiceDefinition>({
+  serviceName,
+  config,
+  queryDefinitions,
+}: {
+  serviceName: string;
+  config: Config;
+  queryDefinitions: TDefinitions;
+}): Promise<SoapService<TDefinitions>> {
+  const WSDL = getWSDLPath({
+    service: serviceName,
+    flavour: config.flavour,
+    XSD_PATH: config.XSD_PATH,
+  });
+
+  const security = prepareSecurity(config);
+
+  const client = await createClientAsync(WSDL, { customDeserializer });
+  client.setSecurity(security);
+
+  const soapQueryFunctions = Object.fromEntries(
+    Object.entries(queryDefinitions).map(([queryName, queryDefinition]) => [
+      queryName,
+      fromSoapDefinition({ queryDefinition, client }),
+    ]),
+  );
+
+  return {
+    ...soapQueryFunctions,
+    __soapClient: client,
+    config,
+  } as SoapService<TDefinitions>;
+}


### PR DESCRIPTION
Queries are declared via `createSoapQueryDefinition(queryDefinition: SoapQueryDefinition)` helper.

Services are built via `createSoapService()`