### PR TITLE
docs: add structured documentation folder with architecture, API, and contributor guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,235 +7,117 @@
 ![Test](https://github.com/DGAC/nmb2b-client-js/workflows/Build,%20test,%20publish/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/DGAC/nmb2b-client-js/branch/master/graph/badge.svg)](https://codecov.io/gh/DGAC/nmb2b-client-js)
 
-Exposes a general purpose Javascript library to interact with NM B2B web services. The idea is to abstract pain points while offering an API that maps the NM B2B WS API.
+A TypeScript client for the **EUROCONTROL Network Manager B2B** web services.
+The library wraps the NM SOAP API and removes most of its pain points: it
+downloads and caches the WSDL/XSD automatically, serializes/deserializes awkward
+XSD types into idiomatic JavaScript values, reorders request keys to satisfy
+SOAP ordering rules, and exposes a fully typed, promise-based API.
 
-NM target version: **27.0.0**
+NM target version: **27.0.0** · Node `>=22` · ESM-only
 
-## Simple usage example
+## Documentation
 
-https://github.com/DGAC/nmb2b-client-js-example
+Full guides live in [`docs/`](./docs/README.md). Start with the one that matches
+what you are trying to do:
 
-# Features
+| If you are…                                      | Read this                                    |
+| ------------------------------------------------ | -------------------------------------------- |
+| **Consuming the library** in your app            | [API & Usage Guide](./docs/api-reference.md) |
+| **Contributing / onboarding** to the repo        | [Getting Started](./docs/getting-started.md) |
+| **Maintaining internals** / curious how it works | [Architecture](./docs/architecture.md)       |
 
-- No WSDL/XSD dependency. The library will download and cache those on start up.
-- Natural serialization/deserialization of certain types.
+A runnable example project: <https://github.com/DGAC/nmb2b-client-js-example>.
 
-For instance, the Flow.retrieveOTMVPlan query expects a `day` attribute with the XSD type `DateYearMonthDay`. This type is a string, representing a date in the `YYYY-MM-DD` format. This library allows you to pass a traditional JS Date object instead.
-
-```typescript
-const res = await Flow.retrieveOTMVPlan({
-  dataset: { type: 'OPERATIONAL' },
-  day: new Date(),
-  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
-});
-```
-
-- Request object key reordering when needed.
-
-In SOAP, key order matters.
-
-```typescript
-// OK
-await Flow.retrieveOTMVPlan({
-  dataset: { type: 'OPERATIONAL' },
-  day: moment.utc().toDate(),
-  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
-});
-
-// Would normally fail
-await const Flow.retrieveOTMVPlan({
-  day: moment.utc().toDate(),
-  dataset: { type: 'OPERATIONAL' },
-  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
-});
-```
-
-The library reorder request object keys to match what's expressed in the XSD/WSDL. Therefore, the second example works fine.
-
-- TypeScript support.
-
-The following example will raise a type error.
-
-```typescript
-// Raises a type error
-await Flow.retrieveOTMVPlan({
-  dataset: { type: 'OPERATIONNAL' }, // Notice the typo
-  day: moment.utc().toDate(),
-  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
-});
-```
-
-- Debug output
-
-Debug output is controlled via the [`debug`](https://npmjs.com/package/debug) package. All debug output from this library is scoped under `@dgac/nmb2b-client` namespace.
-
-Just set a `DEBUG=@dgac/nmb2b-client*` environment variable :
-[![asciicast](https://asciinema.org/a/xWovjkKlkqePBolRl3OqAFBi8.svg)](https://asciinema.org/a/xWovjkKlkqePBolRl3OqAFBi8)
-
-- Hooks
-
-Custom user provided callbacks to be executed when a SOAP query is either started or completed.
-
-# Usage
-
-## Main service
+## 60-second example
 
 ```typescript
 import { createB2BClient } from '@dgac/nmb2b-client';
+import fs from 'node:fs';
 
-// See below for more information about the security argument
-const client = await createB2BClient({ security });
+const client = await createB2BClient({
+  security: {
+    pfx: fs.readFileSync('/path/to/cert.p12'),
+    passphrase: 'your-passphrase',
+  },
+});
 
 const res = await client.Airspace.queryCompleteAIXMDatasets();
+console.log(res.data.datasetSummaries);
 ```
 
-## Per domain service
+## Features
+
+- **No WSDL/XSD dependency.** The schema is fetched from NM at startup and cached
+  on disk, so the package stays small and always matches the targeted NM version.
+- **Natural (de)serialization.** Pass JS `Date`s, get `Date`s back; durations
+  become seconds; numeric strings become integers. See
+  [API & Usage Guide → Natural (de)serialization](./docs/api-reference.md#natural-deserialization).
+- **Request key reordering.** SOAP is order-sensitive; the library reorders
+  request keys to match the WSDL schema, so key order in your code doesn't matter.
+- **Fully typed.** Input typos are compile errors; response shapes are derived
+  from each operation's query definition.
+- **Typed errors.** A non-`OK` SOAP reply throws an `NMB2BError` carrying the NM
+  status code and validation details.
+- **Hooks.** User callbacks run around every query for logging, metrics, tracing.
+- **Tree-shakeable subpath exports.** Besides the main entry, the package exposes
+  `/security`, `/config`, `/types`, and `/utils`.
+
+## Authentication
+
+Provide **one** of three shapes via the `security` option — PFX certificate, PEM
+certificate + key, or API-gateway credentials. See
+[API & Usage Guide → Authentication](./docs/api-reference.md#authentication-security)
+for the full details and env-based loading (`fromEnv()`).
 
 ```typescript
-import { createAirspaceClient } from '@dgac/nmb2b-client';
-
-// See below for more information about the security argument
-const Airspace = await createAirspaceClient({ security });
-
-const res = await Airspace.queryCompleteAIXMDatasets();
-```
-
-## Error handling
-
-```typescript
-import { createAirspaceClient, NMB2BError } from '@dgac/nmb2b-client';
-
-try {
-  const Airspace = await createAirspaceClient({ security });
-
-  const res = await Airspace.queryCompleteAIXMDatasets();
-} catch (err) {
-  if (err instanceof NMB2BError) {
-    if (err.status === 'OBJECT_NOT_FOUND') {
-      // ...
-    }
-  }
-
-  // ...
-}
-```
-
-## B2B Security
-
-Every request to the NM B2B web services must be authenticated using a client certificate. This library needs to be initialized with a `security` object, containing the certificate, key and passphrase associated.
-
-### With P12 certificate
-
-```javascript
-import fs from 'fs';
-
+// PFX / PKCS#12
 const security = {
   pfx: fs.readFileSync('/path/to/cert.p12'),
   passphrase: 'your-passphrase',
 };
 
-createB2BClient({ security }).then((client) => {
-  client.Airspace.queryCompleteAIXMDatasets().then(() => {});
-});
-```
-
-### With PEM certificate
-
-```javascript
-import fs from 'fs';
-
+// PEM certificate + key
 const security = {
-  pem: fs.readFileSync('/path/to/cert.pem'),
+  cert: fs.readFileSync('/path/to/cert.pem'),
   key: fs.readFileSync('/path/to/cert.key'),
-  passphrase: 'your-passphrase',
+  passphrase: 'your-passphrase', // optional if the key is not encrypted
 };
 
-createB2BClient({ security }).then((client) => {
-  client.Airspace.queryCompleteAIXMDatasets().then(() => {});
-});
+// API-gateway credentials (requires endpoint + xsdEndpoint in config)
+const security = {
+  apiKeyId: process.env.B2B_API_KEY_ID!,
+  apiSecretKey: process.env.B2B_API_SECRET_KEY!,
+};
 ```
 
-## Hooks
+## Error handling
 
-Hooks are user provided callbacks which will be executed during the SOAP query process.
-
-Basic example :
+A non-`OK` reply is thrown as an `NMB2BError` with the NM `status`, `reason`, and
+validation details. See
+[API & Usage Guide → Error handling](./docs/api-reference.md#error-handling)
+for the full field reference and status code list.
 
 ```typescript
-const client = await createB2BClient({
-  // ... other options,
-  hooks: [
-    function onRequestStart({ service, query, input }) {
-      console.log(`Query ${query} of service ${service} was invoked with input`, input)
-    }
-  ]
-})
+import { NMB2BError } from '@dgac/nmb2b-client';
+
+try {
+  const res = await client.Airspace.queryCompleteAIXMDatasets();
+} catch (err) {
+  if (err instanceof NMB2BError) {
+    console.error(err.status, err.reason);
+  } else {
+    throw err; // transport / unexpected error
+  }
+}
 ```
 
-A hook can return an optional object containing success / error hooks :
+## Debug output
 
-```typescript
-const client = await createB2BClient({
-  // ... other options,
-  hooks: [
-    function onRequestStart({ service, query, input }) {
-      const startTime = new Date();
+Tracing uses the [`debug`](https://npmjs.com/package/debug) package under the
+`@dgac/nmb2b-client` namespace:
 
-      console.log(
-        `Query ${query} of service ${service} was invoked with input:`,
-        input,
-      );
-
-      return {
-        onRequestSuccess: ({ response }) => {
-          const durationMs = new Date().valueOf() - startTime;
-          console.log(`Query took ${durationMs}ms`);
-          console.log(`Query responded with`, response);
-        },
-        onRequestError: ({ error }) => {
-          const durationMs = new Date().valueOf() - startTime;
-          console.log(`Query took ${durationMs}ms`);
-          console.log(`Query failed with error ${error.message}`);
-        },
-      };
-    },
-  ],
-});
+```bash
+DEBUG='@dgac/nmb2b-client*' node your-app.js
 ```
 
-Hooks can also be async :
-
-```typescript
-const client = await createB2BClient({
-  // ... other options,
-  hooks: [
-    async function onRequestStart({ service, query, input }) {
-      await sendLog(`Query ${query} of service ${service} was invoked`);
-    },
-  ],
-});
-```
-
-To get proper typescript support when creating custom hooks, a `createHook()` function helper is now exported :
-
-```typescript
-import { createHook } from '@dgac/nmb2b-client';
-
-const withPrometheusMetrics = createHook(({ service, query }) => {
-  prometheusCounter.inc({ service, query, status: 'started' });
-
-  return {
-    onRequestSuccess: () =>
-      prometheusCounter.inc({ service, query, status: 'completed' }),
-    onRequestError: () =>
-      prometheusCounter.inc({ service, query, status: 'completed' }),
-  };
-});
-
-// ... in another file
-
-const b2bClient = await createB2BClient({
-  // ... other options
-  hooks: [withPrometheusMetrics],
-});
-```
+[![asciicast](https://asciinema.org/a/xWovjkKlkqePBolRl3OqAFBi8.svg)](https://asciinema.org/a/xWovjkKlkqePBolRl3OqAFBi8)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,95 @@
+# `@dgac/nmb2b-client` — Documentation
+
+A TypeScript client for the **EUROCONTROL Network Manager B2B** web services
+(NM target version **27.0.0**). The library wraps the NM SOAP API and removes
+most of its pain points: it downloads and caches the WSDL/XSD automatically,
+serializes/deserializes awkward XSD types into idiomatic JavaScript values,
+reorders request keys to satisfy SOAP ordering rules, and exposes a fully typed,
+promise-based API.
+
+> Package: `@dgac/nmb2b-client` · License: MIT · Node `>=22` · ESM-only
+
+---
+
+## How this documentation is organised
+
+These docs are written for three audiences. Start with the one that matches
+what you are trying to do.
+
+| If you are…                              | Read this                                    |
+| ---------------------------------------- | -------------------------------------------- |
+| **Consuming the library** in your app    | [API & Usage Guide](./api-reference.md)      |
+| **Contributing / onboarding** to the repo| [Getting Started](./getting-started.md)      |
+| **Maintaining internals** / curious how it works | [Architecture](./architecture.md)    |
+
+### Document index
+
+- **[Getting Started](./getting-started.md)** — repository layout, tooling
+  (pnpm, tsdown, vitest, oxlint), build/test/release workflows, how to add a new
+  SOAP operation, and the fixture-based testing system.
+- **[Architecture](./architecture.md)** — the request lifecycle end to end:
+  configuration, security, WSDL bootstrapping & caching, the SOAP service
+  factory, the serializer/deserializer, hooks, and error handling.
+- **[API & Usage Guide](./api-reference.md)** — the public surface: client
+  factories, configuration options, authentication, every service domain and its
+  operations, the hooks API, and error handling patterns.
+
+---
+
+## 60-second overview
+
+```typescript
+import { createB2BClient } from '@dgac/nmb2b-client';
+import fs from 'node:fs';
+
+// 1. Authenticate (client certificate or API-gateway credentials)
+const client = await createB2BClient({
+  security: {
+    pfx: fs.readFileSync('/path/to/cert.p12'),
+    passphrase: 'your-passphrase',
+  },
+});
+
+// 2. Call a SOAP operation — fully typed, returns a parsed JS object
+const res = await client.Airspace.queryCompleteAIXMDatasets();
+```
+
+Under the hood, `createB2BClient`:
+
+1. Validates the config and security object.
+2. Downloads the NM WSDL/XSD tarball (once) and caches it on disk under a
+   version-stamped directory.
+3. Builds one `soap` client per domain, wiring in the serializer, the custom
+   deserializer, and the configured hooks.
+4. Returns an object with four domain services: `Airspace`, `Flight`, `Flow`,
+   and `GeneralInformation`.
+
+### The four service domains
+
+| Domain               | Service WSDL              | What it covers                                   |
+| -------------------- | ------------------------- | ------------------------------------------------ |
+| `Airspace`           | `AirspaceServices`        | AIXM datasets, AUP / E-AUP airspace use plans    |
+| `Flight`             | `FlightServices`          | Flight plans & flight lists/queries              |
+| `Flow`               | `FlowServices`            | Regulations, hotspots, traffic counts, capacity / OTMV plans |
+| `GeneralInformation` | `GeneralinformationServices` | WSDL discovery, user information              |
+
+See the [API guide](./api-reference.md#service-domains--operations) for the full
+operation list per domain.
+
+---
+
+## Key design ideas at a glance
+
+- **No bundled WSDL/XSD.** The schema is fetched from NM at startup and cached,
+  so the package stays small and always matches the targeted NM version
+  (`27.0.0`, defined in [`src/constants.ts`](../src/constants.ts)).
+- **Schema-driven (de)serialization.** Request objects are walked against the
+  WSDL schema to reorder keys and convert types (e.g. JS `Date` →
+  `DateYearMonthDay` string); responses are converted back (e.g. duration
+  strings → seconds). See [Architecture → Transformers](./architecture.md#5-the-transformers-serializer--deserializer).
+- **Typed errors.** A non-`OK` SOAP reply is thrown as an
+  [`NMB2BError`](../src/utils/NMB2BError.ts) carrying the NM status code and
+  validation details.
+- **Hooks.** User callbacks run around every query for logging, metrics, tracing.
+- **Tree-shakeable subpath exports.** Besides the main entry, the package
+  exposes `/security`, `/config`, `/types`, and `/utils`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,386 @@
+# API & Usage Guide
+
+How to consume `@dgac/nmb2b-client` from your application: installing,
+authenticating, creating clients, calling each service operation, handling
+errors, and using hooks.
+
+For how the library works internally, see [Architecture](./architecture.md).
+
+---
+
+## Installation
+
+```bash
+pnpm add @dgac/nmb2b-client
+# or: npm i @dgac/nmb2b-client / yarn add @dgac/nmb2b-client
+```
+
+Requirements:
+
+- **Node `>=22`**.
+- **ESM only** — use `import`, not `require`.
+- Network access to the NM B2B gateway at startup (to download the WSDL/XSD),
+  and write access to a cache directory (default `/tmp/b2b-xsd`).
+
+A runnable example project: <https://github.com/DGAC/nmb2b-client-js-example>.
+
+---
+
+## Package exports
+
+| Import path                     | Contents                                                        |
+| ------------------------------- | --------------------------------------------------------------- |
+| `@dgac/nmb2b-client`            | `createB2BClient`, the four per-domain factories, `NMB2BError`, `createHook`, and the main types |
+| `@dgac/nmb2b-client/security`   | `Security` type and helpers (`fromEnv`, `fromValues`, `clearCache`, `assertValidSecurity`) |
+| `@dgac/nmb2b-client/config`     | `Config` type, `assertValidConfig`, `getSoapEndpoint`, `getFileUrl`, `obfuscate` |
+| `@dgac/nmb2b-client/types`      | All domain request/reply types + `SafeB2BDeserializedResponse`   |
+| `@dgac/nmb2b-client/utils`      | `NMB2BError`, `extractReferenceLocation`                         |
+
+---
+
+## Authentication (`security`)
+
+Every NM B2B request must be authenticated. Provide **one** of three shapes.
+
+### PFX / PKCS#12 certificate
+
+```typescript
+import fs from 'node:fs';
+
+const security = {
+  pfx: fs.readFileSync('/path/to/cert.p12'),
+  passphrase: 'your-passphrase',
+};
+```
+
+### PEM certificate + key
+
+```typescript
+import fs from 'node:fs';
+
+const security = {
+  cert: fs.readFileSync('/path/to/cert.pem'),
+  key: fs.readFileSync('/path/to/cert.key'),
+  passphrase: 'your-passphrase', // optional if the key is not encrypted
+};
+```
+
+### API-gateway credentials
+
+```typescript
+const security = {
+  apiKeyId: process.env.B2B_API_KEY_ID!,
+  apiSecretKey: process.env.B2B_API_SECRET_KEY!,
+};
+```
+
+> When using `apiKeyId`, you **must** also set `endpoint` and `xsdEndpoint` in
+> the config — the automatic WSDL-discovery SOAP call is not available on the
+> API-gateway path.
+
+### Loading security from the environment
+
+```typescript
+import { fromEnv } from '@dgac/nmb2b-client/security';
+
+const security = fromEnv(); // cached after first call; clearCache() to reset
+```
+
+Recognised variables:
+
+| Variable               | Meaning                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `B2B_CERT`             | Path to a PFX or PEM certificate file                |
+| `B2B_CERT_FORMAT`      | `pfx` (default) or `pem`                             |
+| `B2B_CERT_KEY`         | Path to the PEM key (required when format is `pem`)  |
+| `B2B_CERT_PASSPHRASE`  | Passphrase for the cert/key                          |
+| `B2B_API_KEY_ID`       | API-gateway key id                                   |
+| `B2B_API_SECRET_KEY`   | API-gateway secret (required with `B2B_API_KEY_ID`)  |
+
+---
+
+## Creating a client
+
+### Full client (all domains)
+
+```typescript
+import { createB2BClient } from '@dgac/nmb2b-client';
+
+const client = await createB2BClient({ security });
+
+await client.Airspace.queryCompleteAIXMDatasets();
+await client.Flight.retrieveFlight(/* … */);
+await client.Flow.queryRegulations(/* … */);
+await client.GeneralInformation.retrieveUserInformation(/* … */);
+```
+
+`client` is `{ Airspace, Flight, Flow, GeneralInformation }`.
+
+### Per-domain client
+
+Create just the domain you need (lighter; only that WSDL is loaded):
+
+```typescript
+import {
+  createAirspaceClient,
+  createFlightClient,
+  createFlowClient,
+  createGeneralInformationClient,
+} from '@dgac/nmb2b-client';
+
+const Flow = await createFlowClient({ security });
+await Flow.retrieveOTMVPlan(/* … */);
+```
+
+All factories are `async` because they may download the WSDL and always build
+the SOAP client(s) asynchronously.
+
+---
+
+## Configuration options (`CreateB2BClientOptions`)
+
+Passed to every factory. Only `security` is required.
+
+| Option            | Type                  | Default          | Description                                                                 |
+| ----------------- | --------------------- | ---------------- | --------------------------------------------------------------------------- |
+| `security`        | `Security`            | — (required)     | Authentication; see above.                                                  |
+| `flavour`         | `'OPS' \| 'PREOPS'`   | `'OPS'`          | Target NM environment (production vs pre-ops).                              |
+| `XSD_PATH`        | `string`              | `'/tmp/b2b-xsd'` | Directory where the WSDL/XSD cache is stored.                              |
+| `hooks`           | `SoapQueryHook[]`     | `[]`             | Callbacks run around every query (logging, metrics…).                      |
+| `endpoint`        | `string`              | public NM host   | Override the SOAP gateway base URL.                                         |
+| `xsdEndpoint`     | `string`              | —                | Override where the WSDL tarball is fetched from. Required with `apiKeyId`. |
+| `ignoreWSDLCache` | `boolean`             | `false`          | Force re-download of the WSDL even if cached.                              |
+
+Per-call options (second argument to any operation) are `SoapOptions`:
+
+| Option    | Type     | Description                            |
+| --------- | -------- | -------------------------------------- |
+| `timeout` | `number` | Max request duration in milliseconds.  |
+
+```typescript
+await client.Flight.retrieveFlight(input, { timeout: 30_000 });
+```
+
+> **`sendTime` is injected automatically.** The mandatory NM `sendTime` field is
+> filled with the current time on every call — you never pass it yourself
+> (though you may override it if needed).
+
+---
+
+## Service domains & operations
+
+The library targets **NM version 27.0.0**. Each operation is fully typed; the
+request/reply shapes come from `@dgac/nmb2b-client/types` and the per-domain
+`types.ts` files.
+
+### `Airspace` — `AirspaceServices`
+
+| Operation                   | Purpose                                            |
+| --------------------------- | -------------------------------------------------- |
+| `queryCompleteAIXMDatasets` | List/query complete AIXM datasets.                 |
+| `retrieveAUP`               | Retrieve an Airspace Use Plan.                      |
+| `retrieveAUPChain`          | Retrieve the chain of AUPs.                         |
+| `retrieveEAUPChain`         | Retrieve the European AUP chain.                   |
+
+### `Flight` — `FlightServices`
+
+| Operation                       | Purpose                                          |
+| ------------------------------- | ------------------------------------------------ |
+| `queryFlightPlans`              | Query flight plans.                              |
+| `queryFlightsByAerodrome`       | Flights for a single aerodrome.                  |
+| `queryFlightsByAerodromeSet`    | Flights for a set of aerodromes.                 |
+| `queryFlightsByAircraftOperator`| Flights for an aircraft operator.                |
+| `queryFlightsByAirspace`        | Flights crossing an airspace.                    |
+| `queryFlightsByMeasure`         | Flights impacted by a measure.                   |
+| `queryFlightsByTrafficVolume`   | Flights through a traffic volume.                |
+| `retrieveFlight`                | Retrieve a single flight by id.                  |
+
+### `Flow` — `FlowServices`
+
+| Operation                          | Purpose                                       |
+| ---------------------------------- | --------------------------------------------- |
+| `queryHotspots`                    | Query hotspots.                               |
+| `queryRegulations`                 | Query regulations.                            |
+| `queryTrafficCountsByAirspace`     | Traffic counts for an airspace.               |
+| `queryTrafficCountsByTrafficVolume`| Traffic counts for a traffic volume.          |
+| `retrieveCapacityPlan`             | Retrieve a capacity plan.                     |
+| `retrieveOTMVPlan`                 | Retrieve an OTMV plan.                         |
+| `retrieveRunwayConfigurationPlan`  | Retrieve a runway configuration plan.         |
+| `retrieveSectorConfigurationPlan`  | Retrieve a sector configuration plan.         |
+| `updateCapacityPlan`               | **Write** — update a capacity plan.           |
+| `updateOTMVPlan`                   | **Write** — update an OTMV plan.              |
+
+### `GeneralInformation` — `GeneralinformationServices`
+
+| Operation                 | Purpose                                  |
+| ------------------------- | ---------------------------------------- |
+| `queryNMB2BWSDLs`         | Discover the available WSDL bundles.     |
+| `retrieveUserInformation` | Retrieve the calling user's information. |
+
+---
+
+## Natural (de)serialization
+
+The library converts between idiomatic JS values and NM's XSD string types, so
+you work with `Date`s and numbers, not formatted strings.
+
+```typescript
+// You pass a JS Date; the library formats it as a DateYearMonthDay ("YYYY-MM-DD")
+const res = await Flow.retrieveOTMVPlan({
+  dataset: { type: 'OPERATIONAL' },
+  day: new Date(),
+  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
+});
+```
+
+Conversions applied (see [Architecture §5](./architecture.md#5-the-transformers-serializer--deserializer)):
+
+- **Dates** — JS `Date` ⇄ `DateYearMonthDay` / `DateTimeMinute` / `DateTimeSecond`
+  (always UTC).
+- **Durations** — seconds ⇄ NM duration strings (`DurationHourMinute`,
+  `DurationHourMinuteSecond`, `DurationMinute`).
+- **Numerics** — `FlightLevel_DataType`, `DistanceNM`, `DistanceM`, `Bearing`,
+  `CountsValue`, `OTMVThreshold` parsed to integers on the way back.
+
+### Request key order is handled for you
+
+SOAP is order-sensitive, but the library reorders request keys to match the
+schema, so this works regardless of the order you write the keys:
+
+```typescript
+// Both are accepted — keys are reordered to match the WSDL
+await Flow.retrieveOTMVPlan({
+  day: new Date(),
+  dataset: { type: 'OPERATIONAL' },
+  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
+});
+```
+
+---
+
+## Error handling
+
+A non-`OK` reply is thrown as an `NMB2BError`:
+
+```typescript
+import { createAirspaceClient, NMB2BError } from '@dgac/nmb2b-client';
+
+try {
+  const Airspace = await createAirspaceClient({ security });
+  const res = await Airspace.queryCompleteAIXMDatasets();
+} catch (err) {
+  if (err instanceof NMB2BError) {
+    if (err.status === 'OBJECT_NOT_FOUND') {
+      // handle the specific NM status
+    }
+    console.error(err.status, err.reason, err.inputValidationErrors);
+  } else {
+    // transport / unexpected error (message prefixed with [Query Service.query])
+    throw err;
+  }
+}
+```
+
+`NMB2BError` fields:
+
+| Field                   | Description                                         |
+| ----------------------- | --------------------------------------------------- |
+| `status`                | NM status code (e.g. `OBJECT_NOT_FOUND`, `INVALID_INPUT`). |
+| `reason`                | Human-readable reason, when provided.               |
+| `requestId`             | NM request id (unique with `requestReceptionTime`). |
+| `requestReceptionTime`  | UTC time NM received the request.                   |
+| `sendTime`              | UTC time NM sent the reply.                         |
+| `inputValidationErrors` | Array of `B2B_Error` when `status` is `INVALID_INPUT`. |
+| `outputValidationErrors`| Array of `B2B_Error` when `status` is `INVALID_OUTPUT`. |
+| `warnings`              | Non-fatal warnings, if any.                         |
+| `slaError`              | Set when an SLA was violated.                       |
+
+Possible `status` values include: `OK`, `INVALID_INPUT`, `INVALID_OUTPUT`,
+`INTERNAL_ERROR`, `SERVICE_UNAVAILABLE`, `RESOURCE_OVERLOAD`,
+`REQUEST_COUNT_QUOTA_EXCEEDED`, `PARALLEL_REQUEST_COUNT_QUOTA_EXCEEDED`,
+`REQUEST_OVERBOOKING_REJECTED`, `BANDWIDTH_QUOTAS_EXCEEDED`, `NOT_AUTHORISED`,
+`OBJECT_NOT_FOUND`, `TOO_MANY_RESULTS`, `OBJECT_EXISTS`, `OBJECT_OUTDATED`,
+`CONFLICTING_UPDATE`, `INVALID_DATASET`.
+
+---
+
+## Hooks
+
+Hooks are callbacks run around every SOAP query — ideal for logging, metrics, or
+tracing. Register them via `config.hooks`.
+
+```typescript
+const client = await createB2BClient({
+  security,
+  hooks: [
+    function onRequestStart({ service, query, input }) {
+      console.log(`${service}.${query} called`, input);
+    },
+  ],
+});
+```
+
+A hook may return success/error continuations:
+
+```typescript
+hooks: [
+  function onRequestStart({ service, query, input }) {
+    const start = Date.now();
+    return {
+      onRequestSuccess: ({ response }) =>
+        console.log(`${service}.${query} ok in ${Date.now() - start}ms`),
+      onRequestError: ({ error }) =>
+        console.error(`${service}.${query} failed: ${error.message}`),
+    };
+  },
+],
+```
+
+Hooks can be `async`. For type-safe hooks, use the `createHook` helper:
+
+```typescript
+import { createHook } from '@dgac/nmb2b-client';
+
+const withMetrics = createHook(({ service, query }) => {
+  counter.inc({ service, query, status: 'started' });
+  return {
+    onRequestSuccess: () => counter.inc({ service, query, status: 'completed' }),
+    onRequestError: () => counter.inc({ service, query, status: 'failed' }),
+  };
+});
+
+const client = await createB2BClient({ security, hooks: [withMetrics] });
+```
+
+Notes:
+
+- A built-in debug-logging hook always runs first (see Debug output below).
+- Completion callbacks run in **reverse registration order** (LIFO).
+
+---
+
+## Debug output
+
+Tracing uses the [`debug`](https://www.npmjs.com/package/debug) package under the
+`@dgac/nmb2b-client` namespace. Enable it with an environment variable:
+
+```bash
+DEBUG='@dgac/nmb2b-client*' node your-app.js
+```
+
+You'll see config (with secrets masked), WSDL download steps, and per-query
+`Called with input … / Succeeded / Failed` lines.
+
+---
+
+## OPS vs PREOPS
+
+Set `flavour` to choose the environment:
+
+```typescript
+await createB2BClient({ security, flavour: 'PREOPS' }); // pre-operations
+await createB2BClient({ security, flavour: 'OPS' });     // production (default)
+```
+
+This selects both the host and the URL context, and is stamped into the WSDL
+cache path so OPS and PREOPS schemas don't collide.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,13 +28,13 @@ A runnable example project: <https://github.com/DGAC/nmb2b-client-js-example>.
 
 ## Package exports
 
-| Import path                     | Contents                                                        |
-| ------------------------------- | --------------------------------------------------------------- |
-| `@dgac/nmb2b-client`            | `createB2BClient`, the four per-domain factories, `NMB2BError`, `createHook`, and the main types |
-| `@dgac/nmb2b-client/security`   | `Security` type and helpers (`fromEnv`, `fromValues`, `clearCache`, `assertValidSecurity`) |
-| `@dgac/nmb2b-client/config`     | `Config` type, `assertValidConfig`, `getSoapEndpoint`, `getFileUrl`, `obfuscate` |
-| `@dgac/nmb2b-client/types`      | All domain request/reply types + `SafeB2BDeserializedResponse`   |
-| `@dgac/nmb2b-client/utils`      | `NMB2BError`, `extractReferenceLocation`                         |
+| Import path                   | Contents                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------ |
+| `@dgac/nmb2b-client`          | `createB2BClient`, the four per-domain factories, `NMB2BError`, `createHook`, and the main types |
+| `@dgac/nmb2b-client/security` | `Security` type and helpers (`fromEnv`, `fromValues`, `clearCache`, `assertValidSecurity`)       |
+| `@dgac/nmb2b-client/config`   | `Config` type, `assertValidConfig`, `getSoapEndpoint`, `getFileUrl`, `obfuscate`                 |
+| `@dgac/nmb2b-client/types`    | All domain request/reply types + `SafeB2BDeserializedResponse`                                   |
+| `@dgac/nmb2b-client/utils`    | `NMB2BError`, `extractReferenceLocation`                                                         |
 
 ---
 
@@ -88,14 +88,14 @@ const security = fromEnv(); // cached after first call; clearCache() to reset
 
 Recognised variables:
 
-| Variable               | Meaning                                              |
-| ---------------------- | ---------------------------------------------------- |
-| `B2B_CERT`             | Path to a PFX or PEM certificate file                |
-| `B2B_CERT_FORMAT`      | `pfx` (default) or `pem`                             |
-| `B2B_CERT_KEY`         | Path to the PEM key (required when format is `pem`)  |
-| `B2B_CERT_PASSPHRASE`  | Passphrase for the cert/key                          |
-| `B2B_API_KEY_ID`       | API-gateway key id                                   |
-| `B2B_API_SECRET_KEY`   | API-gateway secret (required with `B2B_API_KEY_ID`)  |
+| Variable              | Meaning                                             |
+| --------------------- | --------------------------------------------------- |
+| `B2B_CERT`            | Path to a PFX or PEM certificate file               |
+| `B2B_CERT_FORMAT`     | `pfx` (default) or `pem`                            |
+| `B2B_CERT_KEY`        | Path to the PEM key (required when format is `pem`) |
+| `B2B_CERT_PASSPHRASE` | Passphrase for the cert/key                         |
+| `B2B_API_KEY_ID`      | API-gateway key id                                  |
+| `B2B_API_SECRET_KEY`  | API-gateway secret (required with `B2B_API_KEY_ID`) |
 
 ---
 
@@ -141,21 +141,21 @@ the SOAP client(s) asynchronously.
 
 Passed to every factory. Only `security` is required.
 
-| Option            | Type                  | Default          | Description                                                                 |
-| ----------------- | --------------------- | ---------------- | --------------------------------------------------------------------------- |
-| `security`        | `Security`            | — (required)     | Authentication; see above.                                                  |
-| `flavour`         | `'OPS' \| 'PREOPS'`   | `'OPS'`          | Target NM environment (production vs pre-ops).                              |
-| `XSD_PATH`        | `string`              | `'/tmp/b2b-xsd'` | Directory where the WSDL/XSD cache is stored.                              |
-| `hooks`           | `SoapQueryHook[]`     | `[]`             | Callbacks run around every query (logging, metrics…).                      |
-| `endpoint`        | `string`              | public NM host   | Override the SOAP gateway base URL.                                         |
-| `xsdEndpoint`     | `string`              | —                | Override where the WSDL tarball is fetched from. Required with `apiKeyId`. |
-| `ignoreWSDLCache` | `boolean`             | `false`          | Force re-download of the WSDL even if cached.                              |
+| Option            | Type                | Default          | Description                                                                |
+| ----------------- | ------------------- | ---------------- | -------------------------------------------------------------------------- |
+| `security`        | `Security`          | — (required)     | Authentication; see above.                                                 |
+| `flavour`         | `'OPS' \| 'PREOPS'` | `'OPS'`          | Target NM environment (production vs pre-ops).                             |
+| `XSD_PATH`        | `string`            | `'/tmp/b2b-xsd'` | Directory where the WSDL/XSD cache is stored.                              |
+| `hooks`           | `SoapQueryHook[]`   | `[]`             | Callbacks run around every query (logging, metrics…).                      |
+| `endpoint`        | `string`            | public NM host   | Override the SOAP gateway base URL.                                        |
+| `xsdEndpoint`     | `string`            | —                | Override where the WSDL tarball is fetched from. Required with `apiKeyId`. |
+| `ignoreWSDLCache` | `boolean`           | `false`          | Force re-download of the WSDL even if cached.                              |
 
 Per-call options (second argument to any operation) are `SoapOptions`:
 
-| Option    | Type     | Description                            |
-| --------- | -------- | -------------------------------------- |
-| `timeout` | `number` | Max request duration in milliseconds.  |
+| Option    | Type     | Description                           |
+| --------- | -------- | ------------------------------------- |
+| `timeout` | `number` | Max request duration in milliseconds. |
 
 ```typescript
 await client.Flight.retrieveFlight(input, { timeout: 30_000 });
@@ -175,40 +175,40 @@ request/reply shapes come from `@dgac/nmb2b-client/types` and the per-domain
 
 ### `Airspace` — `AirspaceServices`
 
-| Operation                   | Purpose                                            |
-| --------------------------- | -------------------------------------------------- |
-| `queryCompleteAIXMDatasets` | List/query complete AIXM datasets.                 |
-| `retrieveAUP`               | Retrieve an Airspace Use Plan.                      |
-| `retrieveAUPChain`          | Retrieve the chain of AUPs.                         |
-| `retrieveEAUPChain`         | Retrieve the European AUP chain.                   |
+| Operation                   | Purpose                            |
+| --------------------------- | ---------------------------------- |
+| `queryCompleteAIXMDatasets` | List/query complete AIXM datasets. |
+| `retrieveAUP`               | Retrieve an Airspace Use Plan.     |
+| `retrieveAUPChain`          | Retrieve the chain of AUPs.        |
+| `retrieveEAUPChain`         | Retrieve the European AUP chain.   |
 
 ### `Flight` — `FlightServices`
 
-| Operation                       | Purpose                                          |
-| ------------------------------- | ------------------------------------------------ |
-| `queryFlightPlans`              | Query flight plans.                              |
-| `queryFlightsByAerodrome`       | Flights for a single aerodrome.                  |
-| `queryFlightsByAerodromeSet`    | Flights for a set of aerodromes.                 |
-| `queryFlightsByAircraftOperator`| Flights for an aircraft operator.                |
-| `queryFlightsByAirspace`        | Flights crossing an airspace.                    |
-| `queryFlightsByMeasure`         | Flights impacted by a measure.                   |
-| `queryFlightsByTrafficVolume`   | Flights through a traffic volume.                |
-| `retrieveFlight`                | Retrieve a single flight by id.                  |
+| Operation                        | Purpose                           |
+| -------------------------------- | --------------------------------- |
+| `queryFlightPlans`               | Query flight plans.               |
+| `queryFlightsByAerodrome`        | Flights for a single aerodrome.   |
+| `queryFlightsByAerodromeSet`     | Flights for a set of aerodromes.  |
+| `queryFlightsByAircraftOperator` | Flights for an aircraft operator. |
+| `queryFlightsByAirspace`         | Flights crossing an airspace.     |
+| `queryFlightsByMeasure`          | Flights impacted by a measure.    |
+| `queryFlightsByTrafficVolume`    | Flights through a traffic volume. |
+| `retrieveFlight`                 | Retrieve a single flight by id.   |
 
 ### `Flow` — `FlowServices`
 
-| Operation                          | Purpose                                       |
-| ---------------------------------- | --------------------------------------------- |
-| `queryHotspots`                    | Query hotspots.                               |
-| `queryRegulations`                 | Query regulations.                            |
-| `queryTrafficCountsByAirspace`     | Traffic counts for an airspace.               |
-| `queryTrafficCountsByTrafficVolume`| Traffic counts for a traffic volume.          |
-| `retrieveCapacityPlan`             | Retrieve a capacity plan.                     |
-| `retrieveOTMVPlan`                 | Retrieve an OTMV plan.                         |
-| `retrieveRunwayConfigurationPlan`  | Retrieve a runway configuration plan.         |
-| `retrieveSectorConfigurationPlan`  | Retrieve a sector configuration plan.         |
-| `updateCapacityPlan`               | **Write** — update a capacity plan.           |
-| `updateOTMVPlan`                   | **Write** — update an OTMV plan.              |
+| Operation                           | Purpose                               |
+| ----------------------------------- | ------------------------------------- |
+| `queryHotspots`                     | Query hotspots.                       |
+| `queryRegulations`                  | Query regulations.                    |
+| `queryTrafficCountsByAirspace`      | Traffic counts for an airspace.       |
+| `queryTrafficCountsByTrafficVolume` | Traffic counts for a traffic volume.  |
+| `retrieveCapacityPlan`              | Retrieve a capacity plan.             |
+| `retrieveOTMVPlan`                  | Retrieve an OTMV plan.                |
+| `retrieveRunwayConfigurationPlan`   | Retrieve a runway configuration plan. |
+| `retrieveSectorConfigurationPlan`   | Retrieve a sector configuration plan. |
+| `updateCapacityPlan`                | **Write** — update a capacity plan.   |
+| `updateOTMVPlan`                    | **Write** — update an OTMV plan.      |
 
 ### `GeneralInformation` — `GeneralinformationServices`
 
@@ -258,6 +258,71 @@ await Flow.retrieveOTMVPlan({
 
 ---
 
+## Response shape
+
+Every operation returns a `Reply` envelope. On success, `status` is `'OK'` and
+the operation-specific payload lives under `data`. You never get a non-`OK`
+reply back as a return value — those throw as `NMB2BError` (see
+[Error handling](#error-handling)).
+
+### The `Reply` envelope
+
+All return types extend `Reply` ([`Common/types.ts`](../src/Common/types.ts)):
+
+| Field                  | Type             | Description                                         |
+| ---------------------- | ---------------- | --------------------------------------------------- |
+| `status`               | `ReplyStatus`    | Always `'OK'` on a successful return.               |
+| `requestId`            | `string`         | NM request id (unique with `requestReceptionTime`). |
+| `requestReceptionTime` | `DateTimeSecond` | UTC time NM received the request.                   |
+| `sendTime`             | `DateTimeSecond` | UTC time NM sent the reply.                         |
+| `warnings`             | `B2B_Error[]`    | Non-fatal warnings, if any.                         |
+| `reason`               | `string`         | Human-readable note, when provided.                 |
+
+### `res.data` holds the payload
+
+Operations that return data use `ReplyWithData<T> = Reply & { data: T }`. The
+`data` field is the typed, deserialized payload — the part you actually want.
+
+```typescript
+// Flow.retrieveOTMVPlan → OTMVPlanRetrievalReply = ReplyWithData<{ plans: OTMVPlans }>
+const res = await Flow.retrieveOTMVPlan({
+  dataset: { type: 'OPERATIONAL' },
+  day: new Date(),
+  otmvsWithDuration: { item: [{ trafficVolume: 'LFERMS' }] },
+});
+
+res.status; // 'OK'
+res.requestId; // NM request id
+res.data.plans; // the OTMV plans (the payload)
+```
+
+```typescript
+// Airspace.queryCompleteAIXMDatasets → ReplyWithData<{ datasetSummaries: CompleteDatasetSummary[] }>
+const ds = await client.Airspace.queryCompleteAIXMDatasets();
+ds.data.datasetSummaries; // CompleteDatasetSummary[]
+```
+
+The exact shape of `data` per operation is defined in the domain's `types.ts`
+(re-exported from `@dgac/nmb2b-client/types`). Inspect the `…Reply` type for the
+operation you're calling to see its `data` structure.
+
+### `SafeB2BDeserializedResponse<T>`
+
+Exported from `@dgac/nmb2b-client/types`. It is a helper alias for
+`SoapDeserializer<T>` — the type produced by the custom deserializer for a given
+response part. Reach for it when you manipulate a slice of a reply's `data` and
+want to keep it typed against the XSD-derived shape (e.g. when pulling a nested
+field out into a variable or a helper function).
+
+```typescript
+import type { SafeB2BDeserializedResponse } from '@dgac/nmb2b-client/types';
+import type { OTMVPlans } from '@dgac/nmb2b-client/types';
+
+const plans: SafeB2BDeserializedResponse<OTMVPlans> = res.data.plans;
+```
+
+---
+
 ## Error handling
 
 A non-`OK` reply is thrown as an `NMB2BError`:
@@ -283,17 +348,17 @@ try {
 
 `NMB2BError` fields:
 
-| Field                   | Description                                         |
-| ----------------------- | --------------------------------------------------- |
-| `status`                | NM status code (e.g. `OBJECT_NOT_FOUND`, `INVALID_INPUT`). |
-| `reason`                | Human-readable reason, when provided.               |
-| `requestId`             | NM request id (unique with `requestReceptionTime`). |
-| `requestReceptionTime`  | UTC time NM received the request.                   |
-| `sendTime`              | UTC time NM sent the reply.                         |
-| `inputValidationErrors` | Array of `B2B_Error` when `status` is `INVALID_INPUT`. |
-| `outputValidationErrors`| Array of `B2B_Error` when `status` is `INVALID_OUTPUT`. |
-| `warnings`              | Non-fatal warnings, if any.                         |
-| `slaError`              | Set when an SLA was violated.                       |
+| Field                    | Description                                                |
+| ------------------------ | ---------------------------------------------------------- |
+| `status`                 | NM status code (e.g. `OBJECT_NOT_FOUND`, `INVALID_INPUT`). |
+| `reason`                 | Human-readable reason, when provided.                      |
+| `requestId`              | NM request id (unique with `requestReceptionTime`).        |
+| `requestReceptionTime`   | UTC time NM received the request.                          |
+| `sendTime`               | UTC time NM sent the reply.                                |
+| `inputValidationErrors`  | Array of `B2B_Error` when `status` is `INVALID_INPUT`.     |
+| `outputValidationErrors` | Array of `B2B_Error` when `status` is `INVALID_OUTPUT`.    |
+| `warnings`               | Non-fatal warnings, if any.                                |
+| `slaError`               | Set when an SLA was violated.                              |
 
 Possible `status` values include: `OK`, `INVALID_INPUT`, `INVALID_OUTPUT`,
 `INTERNAL_ERROR`, `SERVICE_UNAVAILABLE`, `RESOURCE_OVERLOAD`,
@@ -344,7 +409,8 @@ import { createHook } from '@dgac/nmb2b-client';
 const withMetrics = createHook(({ service, query }) => {
   counter.inc({ service, query, status: 'started' });
   return {
-    onRequestSuccess: () => counter.inc({ service, query, status: 'completed' }),
+    onRequestSuccess: () =>
+      counter.inc({ service, query, status: 'completed' }),
     onRequestError: () => counter.inc({ service, query, status: 'failed' }),
   };
 });
@@ -379,7 +445,7 @@ Set `flavour` to choose the environment:
 
 ```typescript
 await createB2BClient({ security, flavour: 'PREOPS' }); // pre-operations
-await createB2BClient({ security, flavour: 'OPS' });     // production (default)
+await createB2BClient({ security, flavour: 'OPS' }); // production (default)
 ```
 
 This selects both the host and the URL context, and is stamped into the WSDL

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,378 @@
+# Architecture
+
+This document explains how `@dgac/nmb2b-client` is built internally: the module
+layout, the end-to-end lifecycle of a SOAP query, and the responsibilities of
+each subsystem. It is aimed at maintainers and anyone who wants to understand or
+extend the library.
+
+For how to *use* the library, see the [API & Usage Guide](./api-reference.md).
+For repo workflows, see [Getting Started](./getting-started.md).
+
+---
+
+## 1. High-level picture
+
+The library is a thin, strongly-typed orchestration layer on top of the
+[`soap`](https://www.npmjs.com/package/soap) package. Its value is concentrated
+in four concerns that the raw `soap` client does not handle well for the NM API:
+
+1. **Bootstrapping** — fetching and caching the WSDL/XSD that the SOAP client
+   needs to exist at all.
+2. **Serialization** — turning idiomatic JS input (Dates, numbers, unordered
+   keys) into the exact XML shape NM expects.
+3. **Deserialization** — turning NM's stringly-typed XML back into JS values.
+4. **Cross-cutting concerns** — typed errors, hooks (logging/metrics), debug
+   tracing, and `sendTime` injection.
+
+```
+createB2BClient(options)
+        │
+        ├─ prepareConfig ............... merge defaults + validate (config.ts, security.ts)
+        │
+        ├─ downloadWSDLIfNeeded ........ fetch + cache WSDL tarball (utils/xsd/*)
+        │
+        └─ Promise.all([
+             getAirspaceClient,         ┐
+             getFlightClient,           │ one soap client per domain
+             getFlowClient,             │ (utils/soap-query-definition.ts)
+             getGeneralInformationClient┘
+           ])
+                 │
+                 └─ per query: serialize → soap call → assertOk → deserialize
+                                (wrapped by hooks)
+```
+
+---
+
+## 2. Module / directory layout
+
+```
+src/
+├── index.ts                  # Public entry point (re-exports the factories + NMB2BError + createHook)
+├── createB2BClient.ts        # Top-level factories: createB2BClient + per-domain factories
+├── config.ts                 # Config type, validation, endpoint/URL builders, obfuscation
+├── security.ts               # Security types (PFX / PEM / API-gateway), validation, env loaders
+├── constants.ts              # B2B_VERSION ('27.0.0'), B2BFlavours ('OPS' | 'PREOPS')
+├── soap.ts                   # SoapOptions (per-call timeout)
+├── types.ts                  # Barrel re-export of all domain types (the `/types` export)
+│
+├── Common/
+│   ├── types.ts              # Shared NM primitives: Reply, B2BRequest, ReplyStatus, NMSet, dates…
+│   └── ServiceInterface.ts   # BaseServiceInterface marker (__soapClient + config)
+│
+├── Airspace/ | Flight/ | Flow/ | GeneralInformation/
+│   ├── index.ts              # getXxxClient(config) + XxxService type; lists the query definitions
+│   ├── <operation>.ts        # One file per SOAP operation (the query definition)
+│   ├── types.ts              # Request/Reply interfaces matching the XSD for this domain
+│   ├── <operation>.e2e.test.ts  # Integration test against a real B2B connection
+│   └── __fixtures__/         # Recorded request/response artifacts for deterministic unit tests
+│
+└── utils/
+    ├── soap-query-definition.ts  # ★ Core: createSoapService / createSoapQueryDefinition / query builder
+    ├── internals.ts          # injectSendTime, assertOkReply, WithInjectedSendTime
+    ├── NMB2BError.ts         # Typed error thrown on non-OK replies
+    ├── assert.ts             # assert() helper (node:assert based)
+    ├── debug.ts              # createDebugLogger — namespaced under @dgac/nmb2b-client
+    ├── extractReferenceLocation.ts
+    ├── timeFormats.ts        # date-fns format strings for NM date/time types
+    ├── fs.ts                 # dirExists / createDir helpers
+    ├── hooks/
+    │   ├── hooks.ts          # SoapQueryHook type + createHook()
+    │   ├── index.ts          # applyHooks() — wraps a query function with start/success/error hooks
+    │   └── withLog.ts        # logHook — the always-on debug logging hook
+    ├── transformers/
+    │   ├── types.ts          # ★ XSD type ⇄ JS value table (input = serialize, output = deserialize)
+    │   ├── serializer.ts     # reorderKeys + prepareSerializer (request side)
+    │   └── index.ts          # deserializer map (response side, fed to the soap client)
+    └── xsd/
+        ├── index.ts          # download() + WSDLExists() — cache check + lockfile
+        ├── getWSDLDownloadURL.ts  # asks NM for the tarball URL via a raw SOAP POST
+        ├── downloadAndExtractWSDL.ts  # streams the tarball, validates content-type, untars
+        ├── createAxiosConfig.ts   # builds axios httpsAgent from the security cert
+        └── paths.ts          # cache directory + per-service WSDL file path (version/endpoint stamped)
+```
+
+Two files marked **★** carry most of the cleverness:
+[`utils/soap-query-definition.ts`](../src/utils/soap-query-definition.ts) (the
+service/query factory) and
+[`utils/transformers/`](../src/utils/transformers/) (the (de)serialization).
+
+---
+
+## 3. The request lifecycle, end to end
+
+### 3.1 Client creation
+
+[`createB2BClient(options)`](../src/createB2BClient.ts) (and the per-domain
+variants `createAirspaceClient`, etc.) all follow the same three steps:
+
+1. **`prepareConfig(options)`** — merges the user options over
+   `CONFIG_DEFAULTS` (`flavour: 'OPS'`, `XSD_PATH: '/tmp/b2b-xsd'`, `hooks: []`),
+   then runs `assertValidConfig` which in turn calls `assertValidSecurity`.
+   Invalid config throws synchronously.
+2. **`downloadWSDLIfNeeded(config)`** — ensures the WSDL/XSD cache is populated
+   (see §4).
+3. **Build the services** — `getAirspaceClient`, `getFlightClient`,
+   `getFlowClient`, `getGeneralInformationClient` run in parallel via
+   `Promise.all`. Each returns a `SoapService`.
+
+The per-domain factory (e.g.
+[`getAirspaceClient`](../src/Airspace/index.ts)) calls `createSoapService` with:
+
+- a `serviceName` (e.g. `'AirspaceServices'`) used to resolve the WSDL file path,
+- the shared `config`,
+- a `queryDefinitions` object mapping operation name → query definition.
+
+### 3.2 Building a SOAP service
+
+[`createSoapService`](../src/utils/soap-query-definition.ts):
+
+1. Resolves the WSDL path via `getServiceWSDLFilePath` (version + flavour stamped).
+2. Builds the `soap` security object via `prepareSecurity(config)`.
+3. `createClientAsync(WSDL, { customDeserializer })` — note the **custom
+   deserializer** is injected here so every response is post-processed.
+4. `client.setSecurity(...)`; if `config.endpoint` is set, `client.setEndpoint(...)`.
+5. Delegates to `createSoapServiceFromSoapClient`, which turns each query
+   definition into a callable function (see §3.3) and returns:
+   ```ts
+   { __soapClient: client, config, ...queryFunctions }
+   ```
+
+### 3.3 Building a single query function
+
+For each entry in `queryDefinitions`,
+`buildQueryFunctionFromSoapDefinition` does the following **once, at build time**:
+
+1. `queryDefinition.getSchema(client)` — pulls the input schema for this
+   operation out of `client.describe()`. This is the WSDL-derived shape used to
+   drive serialization. Example from
+   [`retrieveAUP.ts`](../src/Airspace/retrieveAUP.ts):
+   ```ts
+   getSchema: (client) =>
+     client.describe().AirspaceAvailabilityService
+       .AirspaceAvailabilityPort.retrieveAUP.input
+   ```
+2. `prepareSerializer(schema)` — builds a fast, schema-specific serializer.
+3. Resolves the actual SOAP call: `queryDefinition.executeQuery?.(client)` or, by
+   default, `client[`${query}Async`]` (the promisified method `soap` generates).
+4. Wraps everything with `applyHooks(...)`.
+
+The returned function, **at call time**, does:
+
+```
+input
+ → injectSendTime(input)        # adds a fresh sendTime: Date if absent
+ → serializer(...)              # reorder keys + convert JS values → XSD strings
+ → queryFn(...)  ──► soap ──► NM B2B over HTTPS
+ → [result]                     # soap returns a tuple; we take [0]
+ → assertOkReply(result)        # throw NMB2BError if status !== 'OK'
+ → return result
+```
+
+Any thrown error that is **not** an `AssertionError` or `NMB2BError` is wrapped
+in a descriptive `Error` (with the original attached as `cause`) tagged with the
+`service.query` name.
+
+### 3.4 `sendTime` injection
+
+Every NM request carries a mandatory `sendTime`. The public input type for each
+operation uses `WithInjectedSendTime<T>` (from
+[`internals.ts`](../src/utils/internals.ts)), which makes `sendTime` optional —
+[`injectSendTime`](../src/utils/internals.ts) fills it with `new Date()` at call
+time unless the caller supplied one. This is why you never pass `sendTime`
+yourself.
+
+---
+
+## 4. WSDL/XSD bootstrapping & caching
+
+Lives in [`utils/xsd/`](../src/utils/xsd/). The SOAP client cannot be created
+without local WSDL files, so this runs before any service is built.
+
+### 4.1 Cache layout
+
+[`paths.ts`](../src/utils/xsd/paths.ts) computes a **version-stamped** cache
+directory under `config.XSD_PATH` (default `/tmp/b2b-xsd`):
+
+- Default NM endpoint: `<XSD_PATH>/27.0.0-network-manager`
+- Custom `xsdEndpoint`: `<XSD_PATH>/27.0.0-<sha256(endpoint)[:8]>`
+
+Each service WSDL is then `<dir>/<Service>_<FLAVOUR>_<VERSION>.wsdl`, e.g.
+`AirspaceServices_OPS_27.0.0.wsdl`.
+
+### 4.2 Download flow ([`index.ts → download`](../src/utils/xsd/index.ts))
+
+1. Ensure the cache directory exists.
+2. **Acquire a file lock** on the directory with
+   [`proper-lockfile`](https://www.npmjs.com/package/proper-lockfile) (5 retries).
+   This makes concurrent processes / parallel domain factories safe — only one
+   downloads, the rest wait then find the cache populated.
+3. If `WSDLExists` (directory non-empty) and not `ignoreWSDLCache` → return early.
+4. Otherwise `getWSDLDownloadURL(config)` then `downloadAndExtractWSDL(url, …)`.
+5. Release the lock in a `finally`.
+
+### 4.3 Resolving the tarball URL ([`getWSDLDownloadURL.ts`](../src/utils/xsd/getWSDLDownloadURL.ts))
+
+- If `xsdEndpoint` is provided, it is returned directly (used for API-gateway
+  auth and for mocking in tests).
+- Otherwise the library sends a **raw, hand-written SOAP envelope** (a
+  `NMB2BWSDLsRequest`) via `axios` POST to the SOAP gateway, then extracts the
+  `<id>…</id>` of the tarball from the text response and turns it into an
+  absolute file URL with `getFileUrl`.
+- Note: API-gateway (`apiKeyId`) auth cannot use this discovery path, which is
+  why `assertValidConfig` requires both `endpoint` and `xsdEndpoint` when an
+  `apiKeyId` is used.
+
+### 4.4 Download & extract ([`downloadAndExtractWSDL.ts`](../src/utils/xsd/downloadAndExtractWSDL.ts))
+
+- Streams the URL with `axios` (`responseType: 'stream'`, 15 s timeout), using an
+  `httpsAgent` built from the client certificate (`createAxiosConfig`).
+- Guards against HTML/error pages by checking the `content-type` is a binary
+  format (`gzip` / `octet-stream` / `x-tar`).
+- Pipes the stream through `tar.extract({ cwd: outputDir, strip: 1 })`.
+
+---
+
+## 5. The transformers (serializer & deserializer)
+
+The heart of the "natural types" feature. The mapping table lives in
+[`transformers/types.ts`](../src/utils/transformers/types.ts): each XSD type name
+maps to an `{ input, output }` pair.
+
+- **`input`** is the **serialize** function (JS → XSD string), used on requests.
+- **`output`** is the **deserialize** function (XSD string → JS), used on replies.
+
+Examples:
+
+| XSD type           | `input` (request)             | `output` (reply)               |
+| ------------------ | ----------------------------- | ------------------------------ |
+| `DateYearMonthDay` | `Date` → `"YYYY-MM-DD"`       | string → `Date` (UTC)          |
+| `DateTimeMinute`   | `Date` → `"YYYY-MM-DD hh:mm"` | string → `Date` (UTC)          |
+| `DurationHourMinute` | seconds → `"HHMM"`          | `"HHMM"` → seconds             |
+| `DurationMinute`   | seconds → minutes             | minutes → seconds              |
+| `FlightLevel_DataType`, `DistanceNM`, `Bearing`, … | (none) | string → integer |
+
+All dates are treated as **UTC** (via `@date-fns/utc`).
+
+### 5.1 Serializer (request side) — [`serializer.ts`](../src/utils/transformers/serializer.ts)
+
+`prepareSerializer(schema)` returns a pipeline:
+
+1. **`reorderKeys(schema)`** — SOAP is order-sensitive. This recursively rebuilds
+   the input object so its keys follow the WSDL schema order, descending into
+   nested objects and arrays (keys suffixed `[]` in the schema indicate arrays).
+   Keys not present in the input are skipped; namespace metadata
+   (`targetNSAlias`, `targetNamespace`) is ignored.
+2. **`evolve(transformer)`** ([remeda](https://remedajs.com/)) — applies the per-field
+   `input` converters built by `prepareTransformer`, which walks the same schema
+   and, for each leaf whose XSD type has an `input` function, registers it
+   (mapping over arrays where needed).
+
+This is why the README's "wrong key order still works" and "pass a JS `Date`"
+examples hold.
+
+### 5.2 Deserializer (response side) — [`transformers/index.ts`](../src/utils/transformers/index.ts)
+
+`deserializer` is simply the `{ typeName: output }` map derived from the same
+table. It is passed to `createClientAsync` as `customDeserializer`, so the `soap`
+package applies these conversions automatically while parsing the XML reply —
+durations become seconds, dates become `Date`, numeric strings become integers.
+
+---
+
+## 6. Hooks
+
+A hook is a `SoapQueryHook` ([`hooks/hooks.ts`](../src/utils/hooks/hooks.ts)):
+a function called with `{ service, query, input }` when a query starts. It may
+return `{ onRequestSuccess?, onRequestError? }` callbacks for completion.
+
+[`applyHooks`](../src/utils/hooks/index.ts) wraps each query function:
+
+- On start, it runs every hook (sequentially, awaited), collecting the
+  success/error continuations. Continuations are `unshift`-ed, so they run in
+  **reverse registration order** (LIFO) — like middleware unwinding.
+- On success it runs all `onRequestSuccess({ service, query, response })`.
+- On error it runs all `onRequestError({ service, query, error })`, then rethrows.
+
+The built-in [`logHook`](../src/utils/hooks/withLog.ts) is always prepended to
+the user's hooks, providing `debug`-namespaced tracing for every call. User
+hooks come from `config.hooks`.
+
+---
+
+## 7. Configuration & endpoints
+
+[`config.ts`](../src/config.ts) owns config validation and URL construction:
+
+- **`assertValidConfig`** — requires a valid `security`, a valid `flavour`, and
+  (for API-gateway auth) both `endpoint` and `xsdEndpoint`.
+- **`getSoapEndpoint(config)`** — builds the gateway URL:
+  `<root>/<B2B_OPS|B2B_PREOPS>/gateway/spec/27.0.0`, where root is the public
+  OPS/PREOPS host unless `endpoint` overrides it.
+- **`getFileUrl(path, config)`** — builds the file-download URL
+  (`FILE_OPS`/`FILE_PREOPS`); not supported when `endpoint` is overridden.
+- **`obfuscate(config)`** — masks every `security` value for safe debug logging.
+
+`OPS` vs `PREOPS` (the **flavour**) selects production vs. pre-operations NM
+environments; it is reflected in both the host and the URL context segment.
+
+---
+
+## 8. Security / authentication
+
+[`security.ts`](../src/security.ts) supports three mutually-exclusive shapes,
+validated by `assertValidSecurity` and converted to a `soap` `ISecurity` by
+`prepareSecurity`:
+
+| Shape          | Fields                          | `soap` mechanism            |
+| -------------- | ------------------------------- | --------------------------- |
+| `PfxSecurity`  | `pfx: Buffer`, `passphrase`     | `ClientSSLSecurityPFX`      |
+| `PemSecurity`  | `cert: Buffer`, `key: Buffer`, `passphrase?` | `ClientSSLSecurity`        |
+| `ApiGwSecurity`| `apiKeyId`, `apiSecretKey`      | `BasicAuthSecurity`         |
+
+It also provides env-based loaders: `fromEnv()` (cached) and `fromValues(env)`
+read `B2B_CERT`, `B2B_CERT_KEY`, `B2B_CERT_PASSPHRASE`, `B2B_CERT_FORMAT`
+(`pfx`/`pem`), or `B2B_API_KEY_ID` / `B2B_API_SECRET_KEY`. `clearCache()` resets
+the `fromEnv` cache.
+
+---
+
+## 9. Error handling
+
+- A SOAP reply always has a `status` ([`ReplyStatus`](../src/Common/types.ts)).
+- [`assertOkReply`](../src/utils/internals.ts) throws an
+  [`NMB2BError`](../src/utils/NMB2BError.ts) when `status !== 'OK'`.
+- `NMB2BError` exposes the NM `status`, plus `requestId`, `requestReceptionTime`,
+  `sendTime`, `inputValidationErrors`, `warnings`, `slaError`, and `reason`. Its
+  `message` is `status` (optionally `status: reason`).
+- Lower-level/transport failures surface as a wrapped `Error` with a
+  `[Query Service.query] …` prefix and the original error as `cause`.
+
+---
+
+## 10. Type system notes
+
+- Domain request/reply interfaces live in each `src/<Domain>/types.ts` and are
+  re-exported through [`src/types.ts`](../src/types.ts) (the `/types` subpath).
+- [`Common/types.ts`](../src/Common/types.ts) holds NM primitives: `Reply`,
+  `B2BRequest`, `NMSet<A>`/`NMList<A>`/`NMMap<K,V>`, date aliases, `Dataset`,
+  `ReplyStatus`, `B2B_Error`, etc.
+- The `SoapService<TDefinitions>` mapped type derives the callable signature of
+  each operation from its query definition, so `client.Flow.retrieveOTMVPlan` is
+  typed directly from the `retrieveOTMVPlan` definition — input typos are
+  compile errors.
+
+---
+
+## 11. Build & module format
+
+- **ESM-only** (`"type": "module"`), Node `>=22`.
+- Built with [`tsdown`](https://tsdown.dev) ([`tsdown.config.ts`](../tsdown.config.ts)):
+  multiple entry points (`index`, `utils/index`, `types`, `security`, `config`),
+  `target: node22`, `dts: true`, `sourcemap: true`, `unbundle: true` (preserves
+  the module structure rather than bundling into one file).
+- Subpath exports map to the built `.mjs` / `.d.mts` files (see `exports` in
+  [`package.json`](../package.json)): `.`, `./security`, `./config`, `./types`,
+  `./utils`.
+
+See [Getting Started](./getting-started.md) for the full build/test/release flow.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,212 @@
+# Getting Started (Contributor Guide)
+
+Onboarding for working **on** `@dgac/nmb2b-client`: repo layout, tooling,
+build/test/release workflows, and how to add a new SOAP operation.
+
+For using the published library, see the [API & Usage Guide](./api-reference.md).
+For internals, see [Architecture](./architecture.md).
+
+---
+
+## Prerequisites
+
+- **Node `>=22`**.
+- **pnpm only** — `pnpm@11.8.0` (pinned via `packageManager`).
+  `npm install` / `yarn install` are **forbidden** (see [`AGENTS.md`](../AGENTS.md)).
+- For E2E tests / fixture recording: valid NM B2B credentials in a `.env` file.
+
+```bash
+pnpm install
+```
+
+---
+
+## Repository layout
+
+```
+src/                  # Library source (see Architecture for the full map)
+  <Domain>/           # Airspace, Flight, Flow, GeneralInformation
+    index.ts          # getXxxClient + service definition
+    <operation>.ts    # one file per SOAP operation
+    types.ts          # request/reply types matching the XSD
+    *.e2e.test.ts     # integration tests (real B2B)
+    __fixtures__/     # recorded interactions for deterministic unit tests
+  Common/             # shared NM types + base interface
+  utils/              # soap factory, transformers, xsd bootstrap, hooks, helpers
+tests/                # test harness: msw setup, options, runner, fixtures
+scripts/              # downloadWSDL.ts, update-fixtures.ts
+.changeset/           # changesets for versioning/release
+docs/                 # this documentation
+```
+
+Project conventions are codified in [`AGENTS.md`](../AGENTS.md) — read it before
+contributing. Highlights:
+
+- One SOAP operation per file: `src/<Domain>/<Action>.ts`.
+- Types matching the XSD go in `src/<Domain>/types.ts`; reuse from
+  `src/types.ts`/`Common` where possible.
+- `any` is forbidden; tests must not hardcode secrets.
+
+---
+
+## Tooling
+
+| Concern        | Tool                                   | Config                                  |
+| -------------- | -------------------------------------- | --------------------------------------- |
+| Package manager| **pnpm**                               | [`pnpm-workspace.yaml`](../pnpm-workspace.yaml) |
+| Build / bundle | [**tsdown**](https://tsdown.dev)       | [`tsdown.config.ts`](../tsdown.config.ts) |
+| Type checking  | **tsc** (`--noEmit`)                   | [`tsconfig.json`](../tsconfig.json)     |
+| Linting        | [**oxlint**](https://oxc.rs) (type-aware) | [`oxlint.config.ts`](../oxlint.config.ts) |
+| Tests          | [**vitest**](https://vitest.dev)       | [`vitest.config.ts`](../vitest.config.ts) |
+| HTTP mocking   | [**msw**](https://mswjs.io)            | [`tests/setupMsw.ts`](../tests/setupMsw.ts) |
+| Versioning     | [**changesets**](https://github.com/changesets/changesets) | [`.changeset/`](../.changeset/) |
+| Formatting     | **prettier**                           | [`.prettierrc`](../.prettierrc)         |
+
+---
+
+## npm scripts
+
+From [`package.json`](../package.json):
+
+| Script                  | What it does                                                     |
+| ----------------------- | --------------------------------------------------------------- |
+| `pnpm build`            | Bundle with tsdown → `dist/` (ESM + `.d.mts` + sourcemaps).      |
+| `pnpm clean`            | `rimraf dist`.                                                   |
+| `pnpm typecheck`        | `tsc --noEmit`.                                                  |
+| `pnpm lint`             | oxlint (type-aware, reports unused disable directives).         |
+| `pnpm lint:ci`          | Lint with GitHub-formatted output.                              |
+| `pnpm test`             | Run vitest (watch mode).                                        |
+| `pnpm test:unit`        | Unit project only (mocked, no network).                        |
+| `pnpm test:e2e`         | E2E project only (real B2B connection).                        |
+| `pnpm test:ci`          | Single run + junit + coverage + typecheck.                     |
+| `pnpm downloadWSDL`     | Run [`scripts/downloadWSDL.ts`](../scripts/downloadWSDL.ts).     |
+| `pnpm update-fixtures`  | Record/refresh fixtures from the real B2B API (needs `.env`).   |
+| `pnpm release`          | `pnpm build && changeset publish`.                             |
+
+### Validate your work
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test:unit --no-watch
+```
+
+---
+
+## Testing model
+
+Vitest is split into two **projects** ([`vitest.config.ts`](../vitest.config.ts)):
+
+### `unit` project
+
+- Excludes `*.e2e.test.ts`.
+- Uses **msw** ([`tests/setupMsw.ts`](../tests/setupMsw.ts)) to mock the B2B
+  endpoint — **no real network calls**.
+- Runs with mock credentials and mock endpoints injected via env
+  (`B2B_API_KEY_ID=mock-…`, `B2B_ENDPOINT=…`, etc.).
+- Deterministic; this is what CI relies on.
+
+### `e2e` project
+
+- Includes only `src/**/*.e2e.test.ts`, 20 s timeout.
+- Talks to a **real** B2B connection using credentials from the environment.
+- Guard real-network tests with `test.runIf(shouldUseRealB2BConnection)` and
+  initialize clients from `TEST_B2B_OPTIONS` (`tests/options.ts`). Never
+  hardcode secrets.
+
+A global setup ([`tests/ensureWSDLPresence.ts`](../tests/ensureWSDLPresence.ts))
+makes sure the WSDL cache exists before tests run.
+
+---
+
+## Fixture-based unit testing
+
+Unit tests replay **recorded** real API interactions so they stay deterministic.
+The custom framework lives in [`tests/utils/`](../tests/utils/) and is described
+in [`AGENTS.md`](../AGENTS.md).
+
+A fixture is defined per operation in `src/<Domain>/__fixtures__/<Action>.ts`
+with `defineFixture(serviceMethod)`:
+
+- **`.describe(text)`** — *(required)* scenario description.
+- **`.setup()`** — *(optional, recording only)* prepares live data (e.g. find a
+  valid flight id); returns `variables`.
+- **`.run()`** — *(required)* executes the SOAP call; receives `variables`.
+- **`.test()`** — one or more vitest assertions; receives
+  `{ expect, result, variables }`. Use `expectSnapshot()` for standard snapshots.
+
+Recorded sidecar artifacts live in
+`src/<Domain>/__fixtures__/<Action>/<scenario>.*` (JSON context, XML mock, JSON
+result snapshot).
+
+**Recording / refreshing** (requires valid B2B credentials in `.env`):
+
+```bash
+pnpm update-fixtures
+```
+
+**Registering** fixtures in a domain test (`src/<Domain>/<Domain>.test.ts`):
+
+```typescript
+/// <reference types="vite/client" />
+import { registerFixtures } from '../../tests/utils/runner';
+import { describe } from 'vitest';
+
+describe('MyDomain Fixtures', async () => {
+  const fixtures = import.meta.glob('./__fixtures__/*.ts', { eager: true });
+  await registerFixtures(fixtures, import.meta.url);
+});
+```
+
+---
+
+## How to add a new SOAP operation
+
+1. **Create the operation file** `src/<Domain>/<newOperation>.ts` using
+   `createSoapQueryDefinition`:
+
+   ```typescript
+   import { createSoapQueryDefinition } from '../utils/soap-query-definition.ts';
+   import type { MyRequest, MyReply } from './types.ts';
+
+   export const newOperation = createSoapQueryDefinition<MyRequest, MyReply>({
+     service: 'Flow',           // logical service name (used in logs/errors)
+     query: 'newOperation',     // matches the soap client `${query}Async` method
+     getSchema: (client) =>
+       client.describe().SomeService.SomePort.newOperation.input,
+   });
+   ```
+
+   Find the right `describe()` path by inspecting `client.describe()` for the
+   target WSDL (an existing operation in the same domain is the best template).
+
+2. **Add request/reply types** to `src/<Domain>/types.ts`, reusing primitives
+   from [`Common/types.ts`](../src/Common/types.ts) (`Reply`, `NMSet`, date
+   aliases, etc.). `any` is not allowed.
+
+3. **Register it** in `src/<Domain>/index.ts` by adding it to `queryDefinitions`.
+   The `SoapService` type and the callable method are derived automatically.
+
+4. **Add a fixture** under `src/<Domain>/__fixtures__/` and record it with
+   `pnpm update-fixtures`; add an `*.e2e.test.ts` if appropriate.
+
+5. **Validate:** `pnpm lint && pnpm typecheck && pnpm test:unit --no-watch`.
+
+---
+
+## Release process
+
+The project uses **changesets**:
+
+1. After a change, add a changeset:
+   ```bash
+   pnpm changeset
+   ```
+   (choose the semver bump and write a summary).
+2. Merging the changeset's "Version Packages" PR updates the version and
+   `CHANGELOG.md`.
+3. Publishing runs `pnpm release` (`build` + `changeset publish`). The package
+   is published with npm **provenance** (`publishConfig.provenance: true`); only
+   the `dist/` directory is shipped (`files: ["dist"]`).
+
+CI lives under [`.github/`](../.github/).


### PR DESCRIPTION
## Summary

Introduces a `docs/` folder with four markdown guides that document `@dgac/nmb2b-client` end to end:

- **`docs/README.md`** — documentation index with an audience-based routing table (consumer / contributor / maintainer), a 60-second overview, the four service domains, and key design ideas at a glance.
- **`docs/api-reference.md`** — the public surface: installation, package exports, the three authentication shapes (PFX, PEM, API-gateway), client factories, configuration options, every service domain and its operations, natural (de)serialization, error handling with the full `NMB2BError` field reference and status code list, the hooks API, debug output, and OPS vs PREOPS.
- **`docs/architecture.md`** — internals for maintainers: high-level picture, full module/directory layout, the end-to-end request lifecycle, WSDL/XSD bootstrapping & caching, the serializer/deserializer transformers, hooks, config & endpoints, security, error handling, type system notes, and build/module format.
- **`docs/getting-started.md`** — contributor onboarding: prerequisites, repo layout, tooling table, npm scripts, the vitest unit/e2e testing model, the fixture-based unit testing framework, a step-by-step guide to adding a new SOAP operation, and the changesets release process.

## Why

The library previously had only a single `README.md` covering a fraction of its surface. As the client grew to four service domains and 24 operations, consumers had no authoritative reference for authentication options, config, error handling, or response shapes, and contributors had no written onboarding for the fixture system, WSDL caching, or release workflow. These guides consolidate that knowledge in one navigable, audience-segmented location and serve as the single source of truth going forward.

## Testing

Documentation-only change; no code, types, or tests affected.

- Verified all cross-links between docs resolve.
- Verified the operation tables against `src/<Domain>/index.ts` query definitions.
- Verified config options, security shapes, and package exports against `src/config.ts`, `src/security.ts`, `src/index.ts`, and `package.json`.
- `pnpm lint` / `pnpm typecheck` / `pnpm test` not impacted (no source changes).