### PR TITLE
test: `update-fixtures` script can now only update targeted fixtures

### DIFF
--- a/scripts/update-fixtures.ts
+++ b/scripts/update-fixtures.ts
@@ -1,43 +1,38 @@
 import assert from 'node:assert';
 import { glob } from 'node:fs/promises';
 import { join, relative } from 'node:path';
-import type { CreateB2BClientOptions } from '../src/index.ts';
+import type { B2BClient, CreateB2BClientOptions } from '../src/index.ts';
 import { createB2BClient } from '../src/index.ts';
 import { fromValues } from '../src/security.ts';
 import { resolveB2BEnvironment } from '../tests/resolveB2BEnvironment.ts';
 import { FixtureArtifacts } from '../tests/utils/artifacts.ts';
-import { assertIsFixture } from '../tests/utils/fixtures.ts';
+import { assertIsFixture, type Fixture } from '../tests/utils/fixtures.ts';
 
 const ROOT_DIR = join(import.meta.dirname, '..');
 
-async function findFixtureFiles(baseDirectory: string): Promise<string[]> {
-  const files: string[] = [];
-  const pattern = join(baseDirectory, '**', '__fixtures__', '*.ts');
-  for await (const entry of glob(pattern)) {
-    if (!entry.endsWith('.test.ts')) {
-      files.push(entry);
-    }
-  }
-  return files;
-}
+await record();
 
 async function record() {
   console.log('🚀 Starting fixtures recording...');
 
-  // Manually construct options avoiding top-level import side effects from tests/options.ts
-  const env = resolveB2BEnvironment();
-  const options: CreateB2BClientOptions = {
-    flavour: env.B2B_FLAVOUR,
-    XSD_PATH: env.B2B_XSD_PATH,
-    security: fromValues(env),
-    ...(env.B2B_ENDPOINT && { endpoint: env.B2B_ENDPOINT }),
-    ...(env.B2B_XSD_REMOTE_URL && { xsdEndpoint: env.B2B_XSD_REMOTE_URL }),
-  };
+  const filters = process.argv.slice(2);
+  if (filters.length > 0) {
+    console.log(`Applying filters: ${filters.join(', ')}`);
+  }
 
-  const client = await createB2BClient(options);
+  const allFixtureFiles = await findFixtureFiles(join(ROOT_DIR, 'src'));
+  const fixtureFiles = filterFixtures(allFixtureFiles, filters);
 
-  const fixtureFiles = await findFixtureFiles(join(ROOT_DIR, 'src'));
-  console.log(`Found ${fixtureFiles.length} fixture files.`);
+  if (fixtureFiles.length === 0) {
+    console.warn(
+      `⚠️ No fixture files matched the filters: ${filters.join(', ')}`,
+    );
+    return;
+  }
+
+  console.log(`Found ${fixtureFiles.length} fixture files to process.`);
+
+  const client = await initializeB2BClient();
 
   for (const filePath of fixtureFiles) {
     const relativePath = relative(ROOT_DIR, filePath);
@@ -52,40 +47,16 @@ async function record() {
         `Module ${filePath}, export ${exportName} is not a Fixture instance.`,
       );
 
-      const artifacts = new FixtureArtifacts({ filePath, exportName });
-
       console.log(
         `  - Recording fixture: ${exportName} (${fixture.description})...`,
       );
 
-      const setupStart = new Date();
-      const variables = fixture.setupRecording
-        ? await fixture.setupRecording(client)
-        : undefined;
-
-      // Capture mock date (ensure it matches the execution time)
-      const mockDate = setupStart.toISOString();
-
-      assert(
-        fixture.executeOperation,
-        `Module ${filePath}, export ${exportName} is not a complete fixture.`,
-      );
-
-      await fixture.executeOperation(client, variables);
-
-      const serviceClient = client[fixture.service];
-      const lastResponse = serviceClient.__soapClient.lastResponse as unknown;
-
-      assert(
-        lastResponse && typeof lastResponse === 'string',
-        'No SOAP response captured. Did the executeOperation execute a SOAP query?',
-      );
-
-      await artifacts.saveContext({
-        meta: { mockDate },
-        variables,
+      await recordSingleFixture({
+        b2bClient: client,
+        fixture,
+        filePath,
+        exportName,
       });
-      await artifacts.saveMock(lastResponse);
 
       console.log(`    ✅ Success`);
     }
@@ -94,4 +65,83 @@ async function record() {
   console.log('\n✨ Recording complete.');
 }
 
-await record();
+async function initializeB2BClient() {
+  const env = resolveB2BEnvironment();
+  const options: CreateB2BClientOptions = {
+    flavour: env.B2B_FLAVOUR,
+    XSD_PATH: env.B2B_XSD_PATH,
+    security: fromValues(env),
+    ...(env.B2B_ENDPOINT && { endpoint: env.B2B_ENDPOINT }),
+    ...(env.B2B_XSD_REMOTE_URL && { xsdEndpoint: env.B2B_XSD_REMOTE_URL }),
+  };
+
+  const client = await createB2BClient(options);
+
+  return client;
+}
+
+function filterFixtures(fixtures: Array<string>, filters: Array<string>) {
+  if (filters.length === 0) {
+    return fixtures;
+  }
+
+  return fixtures.filter((filePath) => {
+    const relPath = relative(ROOT_DIR, filePath).toLowerCase();
+    return filters.some((filter) => relPath.includes(filter.toLowerCase()));
+  });
+}
+
+async function recordSingleFixture({
+  b2bClient,
+  fixture,
+  filePath,
+  exportName,
+}: {
+  b2bClient: B2BClient;
+  fixture: Fixture;
+  filePath: string;
+  exportName: string;
+}) {
+  const artifacts = new FixtureArtifacts({ filePath, exportName });
+
+  const setupStart = new Date();
+  const variables = fixture.setupRecording
+    ? await fixture.setupRecording(b2bClient)
+    : undefined;
+
+  // Capture mock date (ensure it matches the execution time)
+  const mockDate = setupStart.toISOString();
+
+  assert(
+    fixture.executeOperation,
+    `Module ${filePath}, export ${exportName} is not a complete fixture.`,
+  );
+
+  await fixture.executeOperation(b2bClient, variables);
+
+  const serviceClient = b2bClient[fixture.service];
+  const lastResponse = serviceClient.__soapClient.lastResponse as unknown;
+
+  assert(
+    lastResponse && typeof lastResponse === 'string',
+    'No SOAP response captured. Did the executeOperation execute a SOAP query?',
+  );
+
+  await artifacts.saveContext({
+    meta: { mockDate },
+    variables,
+  });
+
+  await artifacts.saveMock(lastResponse);
+}
+
+async function findFixtureFiles(baseDirectory: string): Promise<string[]> {
+  const files: string[] = [];
+  const pattern = join(baseDirectory, '**', '__fixtures__', '*.ts');
+  for await (const entry of glob(pattern)) {
+    if (!entry.endsWith('.test.ts')) {
+      files.push(entry);
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
Via `pnpm update-fixtures Flight` for instance.