### PR TITLE
chore: remove `vite` dev dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,16 +94,10 @@ We use a custom framework to record real API interactions and replay them determ
 - **Registration**: Domain-level tests (`src/<Domain>/<Domain>.test.ts`) must use `registerFixtures`:
 
   ```typescript
-  /// <reference types="vite/client" />
   import { registerFixtures } from '../../tests/utils/runner';
   import { describe } from 'vitest';
 
   describe('MyDomain Fixtures', async () => {
-    // Load all fixtures in the directory (Eager load required)
-    const fixtures = import.meta.glob('./__fixtures__/*.ts', {
-      eager: true,
-    });
-
-    await registerFixtures(fixtures, import.meta.url);
+    await registerFixtures('./__fixtures__/*.ts', import.meta.url);
   });
   ```

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "oxlint-tsgolint": "^7.0.2001",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
-    "vite": "^8.2.1",
     "vitest": "^4.1.10"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
-      vite:
-        specifier: ^8.2.1
-        version: 8.2.1(@types/node@22.20.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(msw@2.15.0(@types/node@22.20.1)(typescript@7.0.2))(vite@8.2.1(@types/node@22.20.1)(yaml@2.9.0))

--- a/src/Flight/Flight.test.ts
+++ b/src/Flight/Flight.test.ts
@@ -1,11 +1,6 @@
-/// <reference types="vite/client" />
-import { registerFixtures } from '../../tests/utils/runner.ts';
 import { describe } from 'vitest';
+import { registerFixtures } from '../../tests/utils/runner.ts';
 
 describe('Flight Fixtures', async () => {
-  const fixtures = import.meta.glob('./__fixtures__/*.ts', {
-    eager: true,
-  });
-
-  await registerFixtures(fixtures, import.meta.url);
+  await registerFixtures('./__fixtures__/*.ts', import.meta.url);
 });

--- a/src/Flow/Flow.test.ts
+++ b/src/Flow/Flow.test.ts
@@ -1,11 +1,6 @@
-/// <reference types="vite/client" />
 import { registerFixtures } from '../../tests/utils/runner.ts';
 import { describe } from 'vitest';
 
 describe('Flow Fixtures', async () => {
-  const fixtures = import.meta.glob('./__fixtures__/*.ts', {
-    eager: true,
-  });
-
-  await registerFixtures(fixtures, import.meta.url);
+  await registerFixtures('./__fixtures__/*.ts', import.meta.url);
 });

--- a/tests/utils/runner.ts
+++ b/tests/utils/runner.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
+import * as fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { assert, beforeAll, describe, expect, test, vi } from 'vitest';
 import { createB2BClient, type B2BClient } from '../../src/index.ts';
 import { TEST_B2B_OPTIONS } from '../options.ts';
@@ -10,12 +11,14 @@ import { server, SOAP_ENDPOINT } from './msw.ts';
 
 /**
  * Registers tests for fixtures loaded via import.meta.glob.
- * @param fixtureModules - The result of import.meta.glob('./__fixtures__/*.ts', { eager: true })
+ * @param globPattern - A glob pattern matching fixtures files relative to `baseUrl`
  * @param baseUrl - The import.meta.url of the test file, used to resolve absolute paths
  */
-export async function registerFixtures(fixtureModules: Record<string, unknown>, baseUrl: string) {
+export async function registerFixtures(globPattern: string, baseUrl: string) {
   const b2bClient = await createB2BClient(TEST_B2B_OPTIONS);
   const baseDir = path.dirname(fileURLToPath(baseUrl));
+
+  const fixtureModules = await loadModulesFromGlob(globPattern, baseUrl);
 
   for (const [relativePath, mod] of Object.entries(fixtureModules)) {
     const fixturePath = path.resolve(baseDir, relativePath);
@@ -57,6 +60,28 @@ export async function registerFixtures(fixtureModules: Record<string, unknown>, 
       }
     });
   }
+}
+
+async function loadModulesFromGlob(globPattern: string, baseUrl: string) {
+  const cwd = path.dirname(fileURLToPath(baseUrl));
+
+  const fixtureFiles = await Array.fromAsync(
+    fs.glob(globPattern, {
+      cwd,
+    }),
+  );
+
+  const fixtures = Object.fromEntries(
+    await Promise.all(
+      fixtureFiles.map(async (relativeFilePath) => {
+        const importPath = pathToFileURL(path.join(cwd, relativeFilePath)).href;
+        const mod = (await import(importPath)) as unknown;
+        return [relativeFilePath, mod] as const;
+      }),
+    ),
+  );
+
+  return fixtures;
 }
 
 function runFixtureTests<TB2BService extends keyof B2BClient, TVariables, TResult>({


### PR DESCRIPTION
Replace `import.meta.glob` with `fs.glob` + `await import()`